### PR TITLE
Upgrade javadoc plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.0.0-M1</version>
+            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Hi,

this helps with Java 9 support. The pull request is in line with recent changes in Chronicle-Core (etc): 

https://github.com/OpenHFT/Chronicle-Core/blob/master/pom.xml#L86

Best regards,
Martin