### PR TITLE
Bug in MediumEventLoop: EventHandler may be closed without loopFinished() call

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
@@ -256,6 +256,11 @@ public class MediumEventLoop extends AbstractCloseable implements CoreEventLoop,
         loopFinishedQuietly(highHandler);
         if (!mediumHandlers.isEmpty())
             mediumHandlers.forEach(Threads::loopFinishedQuietly);
+        Optional.ofNullable(newHandler.get())
+                .ifPresent(eventHandler -> {
+                    Jvm.warn().on(getClass(), "Handler in newHandler was not accepted before loop finished " + eventHandler);
+                    loopFinishedQuietly(eventHandler);
+                });
     }
 
     private void runLoop() {


### PR DESCRIPTION
In case new event handler is not accepted yet and EventGroup is being closed, we may skip loopFinished() call, which is not good: it's intended to perform cleanup.