### PR TITLE
Improve resolution of worker threads in the presence of DelegatedExecutorService subclasses

### DIFF
--- a/src/test/java/net/openhft/chronicle/threads/ThreadsTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/ThreadsTest.java
@@ -1,0 +1,68 @@
+package net.openhft.chronicle.threads;
+
+import net.openhft.chronicle.core.Jvm;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ThreadsTest extends ThreadsTestCommon {
+
+    @Test
+    public void shouldDumpStackTracesForStuckDelegatedExecutors() {
+        final AtomicBoolean running = new AtomicBoolean(true);
+        final ExecutorService service = Executors.newSingleThreadExecutor(new NamedThreadFactory("non-daemon-test"));
+        service.submit(() -> {
+            while (running.get()) {
+                Jvm.pause(10L);
+            }
+        });
+
+        Threads.shutdown(service);
+        running.set(false);
+        expectException("*** FAILED TO TERMINATE java.util.concurrent.Executors$");
+        expectException("**** THE main/non-daemon-test THREAD DID NOT SHUTDOWN ***");
+        assertExceptionThrown("**** THE main/non-daemon-test THREAD DID NOT SHUTDOWN ***");
+    }
+
+    @Test
+    public void shouldDumpStackTracesForStuckDaemonDelegatedExecutors() {
+        final AtomicBoolean running = new AtomicBoolean(true);
+        final ExecutorService service = Executors.newSingleThreadExecutor(new NamedThreadFactory("daemon-test"));
+        service.submit(() -> {
+            while (running.get()) {
+                Jvm.pause(10L);
+            }
+        });
+
+        Threads.shutdownDaemon(service);
+        running.set(false);
+        expectException("*** FAILED TO TERMINATE java.util.concurrent.Executors$");
+        expectException("**** THE main/daemon-test THREAD DID NOT SHUTDOWN ***");
+        assertExceptionThrown("**** THE main/daemon-test THREAD DID NOT SHUTDOWN ***");
+    }
+
+    @Test
+    public void shouldDumpStackTracesForStuckNestedDelegatedExecutors() {
+        final AtomicBoolean running = new AtomicBoolean(true);
+        final ExecutorService service = Executors.unconfigurableExecutorService(
+                Executors.unconfigurableExecutorService(
+                        Executors.unconfigurableExecutorService(
+                                Executors.newSingleThreadExecutor(new NamedThreadFactory("non-daemon-test"))
+                        )
+                )
+        );
+        service.submit(() -> {
+            while (running.get()) {
+                Jvm.pause(10L);
+            }
+        });
+
+        Threads.shutdown(service);
+        running.set(false);
+        expectException("*** FAILED TO TERMINATE java.util.concurrent.Executors$");
+        expectException("**** THE main/non-daemon-test THREAD DID NOT SHUTDOWN ***");
+        assertExceptionThrown("**** THE main/non-daemon-test THREAD DID NOT SHUTDOWN ***");
+    }
+}

--- a/src/test/java/net/openhft/chronicle/threads/ThreadsTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/threads/ThreadsTestCommon.java
@@ -8,12 +8,14 @@ import net.openhft.chronicle.core.onoes.Slf4jExceptionHandler;
 import net.openhft.chronicle.core.threads.CleaningThread;
 import net.openhft.chronicle.core.threads.ThreadDump;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Predicate;
+
+import static java.lang.String.format;
+import static org.junit.Assert.fail;
 
 public class ThreadsTestCommon {
     private ThreadDump threadDump;
@@ -59,8 +61,22 @@ public class ThreadsTestCommon {
         if (Jvm.hasException(exceptions)) {
             Jvm.dumpException(exceptions);
             Jvm.resetExceptionHandlers();
-            Assert.fail();
+            fail();
         }
+    }
+
+    public void assertExceptionThrown(String message) {
+        String description = format("No exception found containing string `%s`", message);
+        assertExceptionThrown(k -> k.message.contains(message) || (k.throwable != null && k.throwable.getMessage().contains(message)), description);
+    }
+
+    public void assertExceptionThrown(Predicate<ExceptionKey> predicate, String description) {
+        for (ExceptionKey key : exceptions.keySet()) {
+            if (predicate.test(key)) {
+                return;
+            }
+        }
+        fail(description);
     }
 
     @After


### PR DESCRIPTION
We encountered an issue where a DelegatedExecutorService was preventing us from seeing which threads were stuck. I've modified the resolution of worker threads now to resolve delegated ExecutorServices