### PR TITLE
Give threads a chance to terminate gracefully before interrupting them

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/Threads.java
+++ b/src/main/java/net/openhft/chronicle/threads/Threads.java
@@ -128,9 +128,8 @@ public enum Threads {
     public static void shutdown(@NotNull ExecutorService service) {
 
         service.shutdown();
-        // without these 2 here, some threads that were in a LockSupport.parkNanos were taking a long time to shut down
+        // without this here, some threads that were in a LockSupport.parkNanos were taking a long time to shut down
         Threads.unpark(service);
-        Threads.interrupt(service);
         try {
 
             if (!service.awaitTermination(SHUTDOWN_WAIT_MILLIS, TimeUnit.MILLISECONDS)) {


### PR DESCRIPTION
(Fixes #ChronicleEnterprise/Chronicle-Services#238)

## Context

Sometimes `FixedMasterReplicationTest.shouldReplicate` fails because of the following warning
```
WARN VanillaEventLoop Thread still running
net.openhft.chronicle.core.StackTrace: Thread[main/queue-cluster-1-core-event-loop,5,main] on main/replication-test
	at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2039)
	at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
	at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1074)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1134)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
	at net.openhft.chronicle.core.threads.CleaningThread.run(CleaningThread.java:104)
```
Which is from `MediumEventLoop`
```
    @Override
    public void awaitTermination() {
        try {
            service.shutdownNow();
            service.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
        } catch (InterruptedException e) {
            if (thread != null && thread != Thread.currentThread() && thread.isAlive())
                Jvm.warn().on(getClass(), "Thread still running", StackTrace.forThread(thread));
            Thread.currentThread().interrupt();
        }
    }
```
I _think_ the problem is because `Threads.shutdown` immediately interrupts the threads in the service when shutting down
```
    public static void shutdown(@NotNull ExecutorService service) {

        service.shutdown();
        // without these 2 here, some threads that were in a LockSupport.parkNanos were taking a long time to shut down
        Threads.unpark(service);
        Threads.interrupt(service);  <--- HERE
        try {

            if (!service.awaitTermination(SHUTDOWN_WAIT_MILLIS, TimeUnit.MILLISECONDS)) {
                service.shutdownNow();
```
But a few lines down if we don't shutdown gracefully we call `service.shutdownNow` which I think interrupts all the threads.