### PR TITLE
Test that EventGroup.close() is graceful, don't close handlers that end gracefully on stop() (only do that in close())

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/BlockingEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/BlockingEventLoop.java
@@ -144,6 +144,7 @@ public class BlockingEventLoop extends AbstractLifecycleEventLoop implements Eve
 
     private final class Runner implements Runnable {
         private final EventHandler handler;
+        private boolean endedGracefully = false;
 
         public Runner(final EventHandler handler) {
             this.handler = handler;
@@ -162,7 +163,7 @@ public class BlockingEventLoop extends AbstractLifecycleEventLoop implements Eve
                     else
                         pauser.pause();
                 }
-
+                endedGracefully = true;
             } catch (InvalidEventHandlerException e) {
                 // expected and logged below.
             } catch (Throwable t) {
@@ -173,9 +174,11 @@ public class BlockingEventLoop extends AbstractLifecycleEventLoop implements Eve
                 if (Jvm.isDebugEnabled(handler.getClass()))
                     Jvm.debug().on(handler.getClass(), "handler " + asString(handler) + " done.");
                 loopFinishedQuietly(handler);
-                // remove handler for clarity when debugging
-                handlers.remove(handler);
-                closeQuietly(handler);
+                if (!endedGracefully) {
+                    // remove handler for clarity when debugging
+                    handlers.remove(handler);
+                    closeQuietly(handler);
+                }
             }
         }
     }

--- a/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
@@ -233,7 +233,6 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
                 // ignore, already closed
             } finally {
                 loopFinishedAllHandlers();
-                closeAllHandlers();
                 loopStartMS = FINISHED;
                 loopStartNS = FINISHED;
             }


### PR DESCRIPTION
The idea behind separate `stop`/`close` phases is that we wait until all the handlers finish before we start closing the resources they interact with.

This adds some tests to ensure that `EventGroup.close()` behaves this way and that all the individual event loops do too.