### PR TITLE
Use daemon parameter when creating replication EventLoop

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/EventGroup.java
+++ b/src/main/java/net/openhft/chronicle/threads/EventGroup.java
@@ -225,7 +225,7 @@ public class EventGroup
         if (replication == null) {
             final Pauser newReplicationPauser = replicationPauser != null ? replicationPauser : Pauser.balancedUpToMillis(REPLICATION_EVENT_PAUSE_TIME);
             replication = new VanillaEventLoop(this, name + "replication-event-loop", newReplicationPauser,
-                    REPLICATION_EVENT_PAUSE_TIME, true, bindingReplication, EnumSet.of(HandlerPriority.REPLICATION, HandlerPriority.REPLICATION_TIMER));
+                    REPLICATION_EVENT_PAUSE_TIME, daemon, bindingReplication, EnumSet.of(HandlerPriority.REPLICATION, HandlerPriority.REPLICATION_TIMER));
 
             addThreadMonitoring(REPLICATION_MONITOR_INTERVAL_MS, replication);
             if (isAlive())

--- a/src/test/java/net/openhft/chronicle/threads/EventGroupTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventGroupTest.java
@@ -418,6 +418,18 @@ public class EventGroupTest extends ThreadsTestCommon {
         assertTrue(resource.isClosed());
     }
 
+    @Test
+    void daemonParameterShouldBeUsedWhenCreatingReplicationEventLoop() throws IllegalAccessException {
+        try (final EventGroup eventGroup = EventGroup.builder()
+                .withDaemon(false)
+                .withPriorities(HandlerPriority.REPLICATION)
+                .build()) {
+            eventGroup.addHandler(new TestHandler(HandlerPriority.REPLICATION));  // replication EventLoop is lazily created
+            final MediumEventLoop replication = (MediumEventLoop) Jvm.getField(EventGroup.class, "replication").get(eventGroup);
+            assertFalse(replication.daemon);
+        }
+    }
+
     static class CloseableResource extends AbstractCloseable {
 
         public CloseableResource() {


### PR DESCRIPTION
Previously daemon was hard-coded to `true`, if we ran the following, it would terminate immediately despite `withDaemon(false)`.

```
    public static void main(String[] args) {
        final EventGroup eventGroup = EventGroup.builder()
                                                .withDaemon(false)
                                                .withPriorities(HandlerPriority.REPLICATION)
                                                .build();
        eventGroup.addHandler(new EventHandler() {
            @Override
            public boolean action() {
                return false;
            }

            @Override
            public @NotNull HandlerPriority priority() {
                return HandlerPriority.REPLICATION;
            }
        });
        eventGroup.start();
    }
```