### PR TITLE
Dump the monitor and core event loop states when EventGroup times out on startup

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/EventGroup.java
+++ b/src/main/java/net/openhft/chronicle/threads/EventGroup.java
@@ -21,6 +21,7 @@ import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.threads.EventHandler;
 import net.openhft.chronicle.core.threads.EventLoop;
 import net.openhft.chronicle.core.threads.HandlerPriority;
+import net.openhft.chronicle.threads.internal.EventLoopStateRenderer;
 import net.openhft.chronicle.threads.internal.EventLoopThreadHolder;
 import net.openhft.chronicle.threads.internal.ThreadMonitorHarness;
 import org.jetbrains.annotations.NotNull;
@@ -38,6 +39,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static java.lang.String.format;
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 import static net.openhft.chronicle.threads.VanillaEventLoop.NO_CPU;
 
@@ -386,6 +388,11 @@ public class EventGroup
             try {
                 timeoutPauser.pause(WAIT_TO_START_MS, TimeUnit.MILLISECONDS);
             } catch (TimeoutException e) {
+                Jvm.error().on(EventGroup.class, format("Timed out waiting for start!%n" +
+                                "%s%n%n" +
+                                "%s%n%n",
+                        EventLoopStateRenderer.INSTANCE.render("Core", core),
+                        EventLoopStateRenderer.INSTANCE.render("Monitor", monitor)));
                 throw Jvm.rethrow(e);
             }
         }

--- a/src/main/java/net/openhft/chronicle/threads/MonitorEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MonitorEventLoop.java
@@ -216,5 +216,23 @@ public class MonitorEventLoop extends AbstractLifecycleEventLoop implements Runn
         protected void performClose() throws IllegalStateException {
             Closeable.closeQuietly(eventHandler);
         }
+
+        @Override
+        public String toString() {
+            return "IdempotentLoopStartedEventHandler{" +
+                    "eventHandler=" + eventHandler +
+                    '}';
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "MonitorEventLoop{" +
+                "service=" + service +
+                ", parent=" + parent +
+                ", handlers=" + handlers +
+                ", pauser=" + pauser +
+                ", name='" + name + '\'' +
+                '}';
     }
 }

--- a/src/main/java/net/openhft/chronicle/threads/internal/EventLoopStateRenderer.java
+++ b/src/main/java/net/openhft/chronicle/threads/internal/EventLoopStateRenderer.java
@@ -1,0 +1,57 @@
+package net.openhft.chronicle.threads.internal;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.threads.EventLoop;
+import net.openhft.chronicle.threads.AbstractLifecycleEventLoop;
+import net.openhft.chronicle.threads.CoreEventLoop;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Field;
+
+/**
+ * This is a utility to render a verbose summary of the state of an {@link EventLoop}. Useful for debugging.
+ */
+public enum EventLoopStateRenderer {
+    INSTANCE;
+
+    public String render(String name, @Nullable EventLoop eventLoop) {
+        if (eventLoop == null) {
+            return name + " event loop is null";
+        }
+        StringBuilder builder = new StringBuilder();
+        builder.append(name).append(" event loop state\n");
+        builder.append("#toString(): ").append(eventLoop).append('\n');
+        builder.append("Closed: ").append(eventLoop.isClosed()).append('\n');
+        builder.append("Closing: ").append(eventLoop.isClosing()).append('\n');
+        addLifecycleDetails(builder, eventLoop);
+        addCoreEventLoopDetails(builder, eventLoop);
+        return builder.toString();
+    }
+
+    private void addCoreEventLoopDetails(StringBuilder builder, EventLoop eventLoop) {
+        if (eventLoop instanceof CoreEventLoop) {
+            Thread t = ((CoreEventLoop) eventLoop).thread();
+            if (t != null) {
+                builder.append("Thread state: ").append(t.getState()).append('\n');
+                final StackTraceElement[] stackTrace = t.getStackTrace();
+                if (stackTrace.length > 0) {
+                    builder.append("Stack trace:");
+                    Jvm.trimStackTrace(builder, stackTrace);
+                }
+            } else {
+                builder.append("Thread is null\n");
+            }
+        }
+    }
+
+    private void addLifecycleDetails(StringBuilder builder, EventLoop eventLoop) {
+        if (eventLoop instanceof AbstractLifecycleEventLoop) {
+            try {
+                final Field lifecycle = Jvm.getField(eventLoop.getClass(), "lifecycle");
+                builder.append("Lifecycle: ").append(lifecycle.get(eventLoop)).append('\n');
+            } catch (IllegalAccessException e) {
+                Jvm.warn().on(EventLoopStateRenderer.class, "Error getting the lifecycle for " + eventLoop.getClass().getName());
+            }
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/threads/EventGroupBadAffinityTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventGroupBadAffinityTest.java
@@ -1,57 +1,20 @@
 package net.openhft.chronicle.threads;
 
-import net.openhft.chronicle.core.Jvm;
-import net.openhft.chronicle.core.onoes.ExceptionKey;
-import net.openhft.chronicle.core.onoes.Slf4jExceptionHandler;
 import net.openhft.chronicle.core.threads.EventLoop;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
-public class EventGroupBadAffinityTest {
-    private Map<ExceptionKey, Integer> exceptions;
-    private final Map<Predicate<ExceptionKey>, String> expectedExceptions = new LinkedHashMap<>();
-
-    @BeforeEach
-    public void recordExceptions() {
-        exceptions = Jvm.recordExceptions();
-    }
-
-    private void expectException(String message) {
-        expectException(k -> k.message.contains(message) || (k.throwable != null && k.throwable.getMessage().contains(message)), message);
-    }
-
-    private void expectException(Predicate<ExceptionKey> predicate, String description) {
-        expectedExceptions.put(predicate, description);
-    }
-
-    @AfterEach
-    public void checkExceptions() {
-        for (Map.Entry<Predicate<ExceptionKey>, String> expectedException : expectedExceptions.entrySet()) {
-            if (!exceptions.keySet().removeIf(expectedException.getKey()))
-                Slf4jExceptionHandler.WARN.on(getClass(), "No error for " + expectedException.getValue());
-        }
-        expectedExceptions.clear();
-        if (Jvm.hasException(exceptions)) {
-            Jvm.dumpException(exceptions);
-            Jvm.resetExceptionHandlers();
-            fail();
-        }
-    }
+public class EventGroupBadAffinityTest extends ThreadsTestCommon {
 
     @Timeout(5_000)
     @Test
     public void testInvalidAffinity() {
         expectException("Cannot parse 'xxx'");
+        ignoreException("Timed out waiting for start!");
         try (final EventLoop eventGroup = EventGroup.builder().withBinding("xxx").build()) {
             assertThrows(TimeoutException.class, eventGroup::start);
         }

--- a/src/test/java/net/openhft/chronicle/threads/internal/EventLoopStateRendererTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/internal/EventLoopStateRendererTest.java
@@ -1,0 +1,102 @@
+package net.openhft.chronicle.threads.internal;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.threads.EventLoop;
+import net.openhft.chronicle.threads.EventGroup;
+import net.openhft.chronicle.threads.MediumEventLoop;
+import net.openhft.chronicle.threads.MonitorEventLoop;
+import net.openhft.chronicle.threads.Pauser;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EventLoopStateRendererTest {
+
+    @Test
+    void isNullSafe() {
+        assertEquals("Foo event loop is null", EventLoopStateRenderer.INSTANCE.render("Foo", null));
+    }
+
+    @Test
+    void testCanRenderMediumEventLoop() {
+        try (final MediumEventLoop mediumEventLoop = new MediumEventLoop(null, "foobar", Pauser.sleepy(), true, "any")) {
+            mediumEventLoop.start();
+            while (!mediumEventLoop.isAlive()) {
+                Jvm.pause(10);
+            }
+            final String dump = EventLoopStateRenderer.INSTANCE.render("Medium", mediumEventLoop);
+            Jvm.startup().on(EventLoopStateRendererTest.class, dump);
+            assertTrue(dump.contains("Medium event loop state"));
+            assertTrue(dump.contains("Closed: false"));
+            assertTrue(dump.contains("Closing: false"));
+            assertTrue(dump.contains("Lifecycle: STARTED"));
+            assertTrue(dump.contains("Thread state: "));
+        }
+    }
+
+    @Test
+    void testCanRenderStoppedMediumEventLoop() {
+        try (final MediumEventLoop mediumEventLoop = new MediumEventLoop(null, "foobar", Pauser.sleepy(), true, "any")) {
+            mediumEventLoop.start();
+            while (!mediumEventLoop.isAlive()) {
+                Jvm.pause(10);
+            }
+            mediumEventLoop.stop();
+            while (!mediumEventLoop.isStopped()) {
+                Jvm.pause(10);
+            }
+            final String dump = EventLoopStateRenderer.INSTANCE.render("Medium", mediumEventLoop);
+            Jvm.startup().on(EventLoopStateRendererTest.class, dump);
+            assertTrue(dump.contains("Medium event loop state"));
+            assertTrue(dump.contains("Closed: false"));
+            assertTrue(dump.contains("Closing: false"));
+            assertTrue(dump.contains("Lifecycle: STOPPED"));
+            assertTrue(dump.contains("Thread state: "));
+        }
+    }
+
+    @Test
+    void testCanRenderUnstartedMediumEventLoop() {
+        try (final MediumEventLoop mediumEventLoop = new MediumEventLoop(null, "foobar", Pauser.sleepy(), true, "any")) {
+            final String dump = EventLoopStateRenderer.INSTANCE.render("Medium", mediumEventLoop);
+            Jvm.startup().on(EventLoopStateRendererTest.class, dump);
+            assertTrue(dump.contains("Medium event loop state"));
+            assertTrue(dump.contains("Closed: false"));
+            assertTrue(dump.contains("Closing: false"));
+            assertTrue(dump.contains("Lifecycle: NEW"));
+        }
+    }
+
+    @Test
+    void testCanRenderMonitorEventLoop() {
+        try (final MonitorEventLoop monitorEventLoop = new MonitorEventLoop(null, Pauser.sleepy())) {
+            monitorEventLoop.start();
+            while (!monitorEventLoop.isAlive()) {
+                Jvm.pause(10);
+            }
+            final String dump = EventLoopStateRenderer.INSTANCE.render("Monitor", monitorEventLoop);
+            Jvm.startup().on(EventLoopStateRendererTest.class, dump);
+            assertTrue(dump.contains("Monitor event loop state"));
+            assertTrue(dump.contains("Closed: false"));
+            assertTrue(dump.contains("Closing: false"));
+            assertTrue(dump.contains("Lifecycle: STARTED"));
+        }
+    }
+
+    @Test
+    void testCanRenderEventGroup() {
+        try (final EventLoop eventGroup = EventGroup.builder().build()) {
+            eventGroup.start();
+            while (!eventGroup.isAlive()) {
+                Jvm.pause(10);
+            }
+            final String dump = EventLoopStateRenderer.INSTANCE.render("EG", eventGroup);
+            Jvm.startup().on(EventLoopStateRendererTest.class, dump);
+            assertTrue(dump.contains("EG event loop state"));
+            assertTrue(dump.contains("Closed: false"));
+            assertTrue(dump.contains("Closing: false"));
+            assertTrue(dump.contains("Lifecycle: STARTED"));
+        }
+    }
+}


### PR DESCRIPTION
We have heard that this has occurred sometimes, given we think it should never happen it doesn't hurt to dump out some diagnostic details. (Fixes #141)

I opted to not change the `toString` for the EventLoops because the output is very verbose and probably more than what you'd want if just printing the loop. I also access the lifecycle using reflection so as to not expose it. It's an internal detail and we don't want it in the API.

You could argue this could be done by adding a `dumpState` method to the EventLoop interface and implementing it for each loop. But I didn't do it that way so as to not add to the API. This only adds to the internal API. If someone feels strongly we should then I'm open to that argument.