### PR TITLE
Remove use of deprecated system property

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/ExceptionHandlerStrategy.java
+++ b/src/main/java/net/openhft/chronicle/threads/ExceptionHandlerStrategy.java
@@ -6,16 +6,24 @@ import net.openhft.chronicle.core.threads.EventLoop;
 import net.openhft.chronicle.core.threads.InvalidEventHandlerException;
 import net.openhft.chronicle.core.util.ObjectUtils;
 
+/**
+ * Strategy for how to deal with exceptions in handlers
+ * @deprecated in future, the default behaviour will be the only supported behaviour
+ */
+@Deprecated(/* Remove in .25 */)
 @FunctionalInterface
 public interface ExceptionHandlerStrategy {
     String IMPL_PROPERTY = "el.exception.handler";
 
     /**
-     * TODO: use a builder pattern to construct EventLoops so we don't have this system property
      * @return ExceptionHandlerStrategy to use
      */
     static ExceptionHandlerStrategy strategy() {
-        String className = Jvm.getProperty(IMPL_PROPERTY, LogDontRemove.class.getName());
+        String className = Jvm.getProperty(IMPL_PROPERTY);
+        if (className != null)
+            Jvm.warn().on(ExceptionHandlerStrategy.class, IMPL_PROPERTY + " has been deprecated with no replacement");
+        if (className == null)
+            className = LogDontRemove.class.getName();
         try {
             return ObjectUtils.newInstance(className);
         } catch (Exception e) {

--- a/src/test/java/net/openhft/chronicle/threads/EventGroupTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventGroupTest.java
@@ -228,6 +228,7 @@ public class EventGroupTest extends ThreadsTestCommon {
     @Timeout(5_000)
     @Test
     public void checkHandlersClosedImmediatelyOnRuntimeException() throws InterruptedException {
+        expectException("el.exception.handler has been deprecated with no replacement");
         System.setProperty(ExceptionHandlerStrategy.IMPL_PROPERTY, ExceptionHandlerStrategy.LogAndRemove.class.getName());
         try {
             expectException(exceptionKey -> exceptionKey.throwable == RUNTIME_EXCEPTION, "message");
@@ -309,6 +310,7 @@ public class EventGroupTest extends ThreadsTestCommon {
     @Timeout(5_000)
     @Test
     public void checkAllEventHandlerTypesStartRuntimeException() throws InterruptedException {
+        expectException("el.exception.handler has been deprecated with no replacement");
         try {
             System.setProperty(ExceptionHandlerStrategy.IMPL_PROPERTY, ExceptionHandlerStrategy.LogAndRemove.class.getName());
             expectException(exceptionKey -> exceptionKey.throwable == RUNTIME_EXCEPTION, "message");

--- a/src/test/java/net/openhft/chronicle/threads/StopVCloseTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/StopVCloseTest.java
@@ -84,7 +84,7 @@ public class StopVCloseTest extends ThreadsTestCommon {
     public void blockingStopped() throws InterruptedException {
         BlockingEventLoop bel = new BlockingEventLoop("blocking");
         bel.start();
-        BlockingQueue q = new LinkedBlockingQueue();
+        BlockingQueue<String> q = new LinkedBlockingQueue<>();
         AtomicBoolean stopped = new AtomicBoolean();
         AtomicReference<Thread> thread = new AtomicReference<>();
         bel.addHandler(() -> {


### PR DESCRIPTION
I can't find any references to "el.exception.handler" anywhere in our codebase