### PR TITLE
Only suppress exceptions starting the event loop when we're certain they're because the event loop was closed

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
@@ -22,6 +22,7 @@ import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.annotation.HotMethod;
 import net.openhft.chronicle.core.io.AbstractCloseable;
 import net.openhft.chronicle.core.io.Closeable;
+import net.openhft.chronicle.core.io.ClosedIllegalStateException;
 import net.openhft.chronicle.core.threads.EventHandler;
 import net.openhft.chronicle.core.threads.EventLoop;
 import net.openhft.chronicle.core.threads.HandlerPriority;
@@ -221,8 +222,12 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
                     throw new NullPointerException();
                 loopStartedAllHandlers();
                 runLoop();
-            } catch (IllegalStateException e) {
-                // ignore, already closed
+            } catch (ClosedIllegalStateException e) {
+                if (!isClosing()) {
+                    // Event loop isn't closed
+                    Jvm.rethrow(e);
+                }
+                // otherwise ignore, already closed
             } finally {
                 loopFinishedAllHandlers();
                 loopStartNS = FINISHED;
@@ -485,7 +490,6 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
                     mediumHandlers.add(handler);
                     updateMediumHandlersArray();
                     handler.eventLoop(parent != null ? parent : this);
-                    handler.loopStarted();
                 }
                 break;
             }

--- a/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
@@ -27,7 +27,7 @@ import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class MediumEventLoopTest {
+public class MediumEventLoopTest extends ThreadsTest {
 
     @Test
     public void testAddingTwoEventHandlersBeforeStartingLoopIsThreadSafe() {
@@ -46,6 +46,27 @@ public class MediumEventLoopTest {
                         });
                 assertEquals(2, eventLoop.mediumHandlersArray.length);
             }
+        }
+    }
+
+    @Test
+    void illegalStateExceptionsAreLoggedWhenThrownInLoopStarted() {
+        try (MediumEventLoop eventLoop = new MediumEventLoop(null, "name", Pauser.balanced(), true, null)) {
+            class ThrowingHandler implements EventHandler {
+
+                @Override
+                public void loopStarted() {
+                    throw new IllegalStateException("Something went wrong in loopStarted!!!");
+                }
+
+                @Override
+                public boolean action() {
+                    return false;
+                }
+            }
+            eventLoop.addHandler(new ThrowingHandler());
+            eventLoop.start();
+            expectException("Something went wrong in loopStarted!!!");
         }
     }
 


### PR DESCRIPTION
This exception suppression was way too broad