### PR TITLE
Downgrade the "Handler in newHandler was not accepted before loop finished" log message to INFO to reduce test flakiness

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
@@ -249,7 +249,7 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
             mediumHandlers.forEach(Threads::loopFinishedQuietly);
         Optional.ofNullable(newHandler.get())
                 .ifPresent(eventHandler -> {
-                    Jvm.warn().on(getClass(), "Handler in newHandler was not accepted before loop finished " + eventHandler);
+                    Jvm.startup().on(getClass(), "Handler in newHandler was not accepted before loop finished " + eventHandler);
                     loopFinishedQuietly(eventHandler);
                 });
     }
@@ -556,7 +556,7 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
         closeAll(mediumHandlers);
         Optional.ofNullable(newHandler.get())
                 .ifPresent(eventHandler -> {
-                    Jvm.warn().on(getClass(), "Handler in newHandler was not accepted before close " + eventHandler);
+                    Jvm.startup().on(getClass(), "Handler in newHandler was not accepted before close " + eventHandler);
                     Closeable.closeQuietly(eventHandler);
                 });
     }

--- a/src/test/java/net/openhft/chronicle/threads/EventGroupTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventGroupTest.java
@@ -588,7 +588,7 @@ public class EventGroupTest extends ThreadsTestCommon {
 
         @Override
         public void loopStarted() {
-            assertTrue(loopStartedNS.compareAndSet(0, System.nanoTime()), "loopStarted should only ever be called once");
+            assertTrue(loopStartedNS.compareAndSet(0, System.nanoTime()), "loopStarted should only ever be called once " + this);
             started.countDown();
             assertTrue(EventLoop.inEventLoop(), "loopStarted should be called on EL thread (called on `"
                     + Thread.currentThread().getName()

--- a/src/test/java/net/openhft/chronicle/threads/EventLoopConcurrencyStressTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventLoopConcurrencyStressTest.java
@@ -78,7 +78,7 @@ class EventLoopConcurrencyStressTest extends ThreadsTestCommon {
                 allTests.add(DynamicTest.dynamicTest("canConcurrentlyAddTerminatingHandlersAndStartEventLoop: " + params.className() + "/" + priority,
                         () -> canConcurrentlyAddTerminatingHandlersAndStartEventLoop(params::create, priority)));
                 allTests.add(DynamicTest.dynamicTest("canConcurrentlyAddTerminatingHandlersAndStopEventLoop: " + params.className() + "/" + priority,
-                        () -> canConcurrentlyAddTerminatingHandlersAndStartEventLoop(params::create, priority)));
+                        () -> canConcurrentlyAddTerminatingHandlersAndStopEventLoop(params::create, priority)));
             }
             return allTests.stream();
         });
@@ -143,7 +143,6 @@ class EventLoopConcurrencyStressTest extends ThreadsTestCommon {
     }
 
     public void canConcurrentlyAddHandlersAndStopEventLoop(Supplier<AbstractLifecycleEventLoop> eventLoopSupplier, HandlerPriority priority) throws TimeoutException {
-        ignoreException("Handler in newHandler was not accepted before");
         ExecutorService executorService = Executors.newCachedThreadPool();
         try (AbstractLifecycleEventLoop eventLoop = eventLoopSupplier.get()) {
             List<HandlerAdder> handlerAdders = new ArrayList<>();
@@ -195,7 +194,6 @@ class EventLoopConcurrencyStressTest extends ThreadsTestCommon {
     }
 
     public void canConcurrentlyAddTerminatingHandlersAndStopEventLoop(Supplier<AbstractLifecycleEventLoop> eventLoopSupplier, HandlerPriority priority) throws TimeoutException {
-        ignoreException("Handler in newHandler was not accepted before");
         ExecutorService executorService = Executors.newCachedThreadPool();
         try (AbstractLifecycleEventLoop eventLoop = eventLoopSupplier.get()) {
             List<HandlerAdder> handlerAdders = new ArrayList<>();


### PR DESCRIPTION
This is probably controversial. But it feels to me that if you didn't notice for some other reason (i.e. an event handler you expected to be running wasn't running) then you probably don't really care.

This mostly shows up in tests where we start and stop event loops after running only for a short period.

I left the message at info because nobody has debug turned on, but could be convinced to make it a debug message?