### PR TITLE
Increase minBusy

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/Pauser.java
+++ b/src/main/java/net/openhft/chronicle/threads/Pauser.java
@@ -19,6 +19,7 @@ package net.openhft.chronicle.threads;
 
 import net.openhft.affinity.AffinityLock;
 import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.OS;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.TimeUnit;
@@ -33,6 +34,7 @@ public interface Pauser {
 
     boolean BALANCED = getBalanced(); // calculated once
     boolean SLEEPY = getSleepy();  // calculated once
+    int MIN_BUSY = Integer.getInteger("balances.minBusy", OS.isWindows() ? 100_000 : 10_000);
 
     static boolean getBalanced() {
         int procs = AffinityLock.cpuLayout().cpus();
@@ -77,7 +79,7 @@ public interface Pauser {
      */
     static TimingPauser balancedUpToMillis(int millis) {
         return SLEEPY ? sleepy()
-                : new LongPauser(400, 800, 200, Jvm.isDebug() ? 500_000 : millis * 1_000L, TimeUnit.MICROSECONDS);
+                : new LongPauser(MIN_BUSY, 800, 200, Jvm.isDebug() ? 500_000 : millis * 1_000L, TimeUnit.MICROSECONDS);
     }
 
     /**


### PR DESCRIPTION
Pauser.balanced() is poor for modest throughputs of 10/s to 1000/s as it falls asleep too readily. On Windows this can increase the typical latency from 80 us to 7000 us in extreme cases.
For this reason, balanced() has been avoided for benchmarks, but fixing balanced() is a better solution.