### PR TITLE
Add units to time-quantity fields and methods, stop using shared Pauser for BlockingEventLoop

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/ThreadHolder.java
+++ b/src/main/java/net/openhft/chronicle/threads/ThreadHolder.java
@@ -40,5 +40,13 @@ public interface ThreadHolder {
 
     void monitorThreadDelayed(long actionCallDelayNS);
 
-    long timingTolerance();
+    /**
+     * @deprecated Use {@link #timingToleranceNS()} instead
+     */
+    @Deprecated(/* To be removed in x.25 */)
+    default long timingTolerance() {
+        return timingToleranceNS();
+    }
+
+    long timingToleranceNS();
 }

--- a/src/main/java/net/openhft/chronicle/threads/internal/EventLoopThreadHolder.java
+++ b/src/main/java/net/openhft/chronicle/threads/internal/EventLoopThreadHolder.java
@@ -74,11 +74,11 @@ public class EventLoopThreadHolder implements ThreadHolder {
     }
 
     @Override
-    public long timingTolerance() {
-        return monitorIntervalNS + timingError();
+    public long timingToleranceNS() {
+        return monitorIntervalNS + timingErrorNS();
     }
 
-    protected long timingError() {
+    protected long timingErrorNS() {
         return TIMING_ERROR;
     }
 

--- a/src/main/java/net/openhft/chronicle/threads/internal/ThreadMonitorHarness.java
+++ b/src/main/java/net/openhft/chronicle/threads/internal/ThreadMonitorHarness.java
@@ -47,7 +47,7 @@ public class ThreadMonitorHarness implements ThreadMonitor {
             thread.resetTimers();
             return false;
         }
-        if (actionCallDelay > thread.timingTolerance()) {
+        if (actionCallDelay > thread.timingToleranceNS()) {
             if (thread.isAlive())
                 thread.monitorThreadDelayed(actionCallDelay);
             return true;

--- a/src/test/java/net/openhft/chronicle/threads/internal/ThreadsThreadHolderTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/internal/ThreadsThreadHolderTest.java
@@ -1,0 +1,13 @@
+package net.openhft.chronicle.threads.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ThreadsThreadHolderTest {
+
+    @Test
+    void testNanosecondsToMillisWithTenthsPrecision() {
+        assertEquals(1.2d, ThreadsThreadHolder.nanosecondsToMillisWithTenthsPrecision(1_234_567), 0.000000001);
+    }
+}


### PR DESCRIPTION
Just some things I came across when looking at the monitor warnings