### PR TITLE
Default sampler.micros to zero to prevent spurious monitor warnings

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/EventGroup.java
+++ b/src/main/java/net/openhft/chronicle/threads/EventGroup.java
@@ -134,7 +134,7 @@ public class EventGroup
             closeable.add(monitor);
             if (core != null) {
                 monitor.addHandler(new PauserMonitor(pauser, nameWithSlash() + "core-pauser", 300));
-                long samplerMicros = Integer.getInteger("sampler.micros", 50);
+                long samplerMicros = Integer.getInteger("sampler.micros", 0);
                 if (pauser instanceof TimingPauser && samplerMicros > 0)
                     setupTimeLimitMonitor(samplerMicros * 1000, core::loopStartNS);
             }


### PR DESCRIPTION
Setting `sampler.micros` to a non-zero value seems to add a monitor that alerts any time a single iteration of the core event loop takes that long. We see lots of spurious stack traces in the logs with the existing default of 50us.

I've changed the default to 0 (don't monitor), happy to agree on some number higher than 50 micros if we think these messages are interesting.