### PR TITLE
Deprecate Threads.withThreadGroup and initialise GROUP lazily

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/Threads.java
+++ b/src/main/java/net/openhft/chronicle/threads/Threads.java
@@ -41,7 +41,7 @@ public enum Threads {
     ; // none
 
     private static final int MAX_DEPTH_TO_FOLLOW_DELEGATIONS = 20;
-    static final Field GROUP = Jvm.getField(Thread.class, "group");
+    private static Field group;
     static final long SHUTDOWN_WAIT_MILLIS = Jvm.getLong("SHUTDOWN_WAIT_MS", 500L);
     static final ThreadLocal<List<Object>> listTL = ThreadLocal.withInitial(ArrayList::new);
     static ExecutorFactory executorFactory;
@@ -70,6 +70,7 @@ public enum Threads {
         Threads.executorFactory = executorFactory;
     }
 
+    @Deprecated(/* To be removed in 2.24. No replacement */)
     @ForceInline
     public static <R, T extends Throwable> R withThreadGroup(ThreadGroup tg, @NotNull ThrowingCallable<R, T> callable) throws T {
         Thread thread = Thread.currentThread();
@@ -83,10 +84,13 @@ public enum Threads {
         }
     }
 
+    @Deprecated(/* To be removed in 2.24. No replacement */)
     @ForceInline
     public static void setThreadGroup(Thread thread, ThreadGroup tg) {
         try {
-            GROUP.set(thread, tg);
+            if (group == null)
+                 group = Jvm.getField(Thread.class, "group");
+            group.set(thread, tg);
 
         } catch (IllegalAccessException e) {
             throw new AssertionError(e);


### PR DESCRIPTION
This addresses #200 and hopefully we can remove these problematic methods in the next version bump