### PR TITLE
make Builder a Supplier so we can refer to Supplier in config objects…

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/EventGroupBuilder.java
+++ b/src/main/java/net/openhft/chronicle/threads/EventGroupBuilder.java
@@ -21,6 +21,7 @@ package net.openhft.chronicle.threads;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.threads.EventLoop;
 import net.openhft.chronicle.core.threads.HandlerPriority;
+import net.openhft.chronicle.core.util.Builder;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.EnumSet;
@@ -33,7 +34,7 @@ import static net.openhft.chronicle.threads.EventGroup.REPLICATION_EVENT_PAUSE_T
  * Builder for {@link EventGroup}. Implements {@link Supplier} so we can provide this to configuration
  * that expects a Supplier<EventLoop> (e.g. QE, FIX)
  */
-public class EventGroupBuilder implements Supplier<EventLoop> {
+public class EventGroupBuilder implements Builder<EventLoop> {
 
     private boolean daemon = true;
     private Pauser pauser;
@@ -58,6 +59,7 @@ public class EventGroupBuilder implements Supplier<EventLoop> {
     private EventGroupBuilder() {
     }
 
+    @Override
     public EventGroup build() {
         return new EventGroup(daemon,
                 pauserOrDefault(),
@@ -160,10 +162,5 @@ public class EventGroupBuilder implements Supplier<EventLoop> {
 
     public EventGroupBuilder withPriorities(HandlerPriority firstPriority, HandlerPriority... priorities) {
         return withPriorities(EnumSet.of(firstPriority, priorities));
-    }
-
-    @Override
-    public EventLoop get() {
-        return build();
     }
 }

--- a/src/main/java/net/openhft/chronicle/threads/LongPauser.java
+++ b/src/main/java/net/openhft/chronicle/threads/LongPauser.java
@@ -169,7 +169,7 @@ public class LongPauser implements Pauser, TimingPauser {
         long start = System.nanoTime();
         thread = Thread.currentThread();
         pausing.set(true);
-        if (!Thread.currentThread().isInterrupted())
+        if (!thread.isInterrupted())
             LockSupport.parkNanos(delayNs);
         pausing.set(false);
         long time = System.nanoTime() - start;

--- a/src/main/java/net/openhft/chronicle/threads/MilliPauser.java
+++ b/src/main/java/net/openhft/chronicle/threads/MilliPauser.java
@@ -88,7 +88,7 @@ public class MilliPauser implements Pauser {
         long start = System.nanoTime();
         thread = Thread.currentThread();
         pausing.set(true);
-        if (!Thread.currentThread().isInterrupted())
+        if (!thread.isInterrupted())
             LockSupport.parkNanos(delayMS * 1_000_000L);
         pausing.set(false);
         long time = System.nanoTime() - start;


### PR DESCRIPTION
…. Also, misc cleanup

See also https://github.com/OpenHFT/Chronicle-Core/pull/591