### PR TITLE
Make AbstractLifecycleEventLoop#awaitTermination protected

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/AbstractLifecycleEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/AbstractLifecycleEventLoop.java
@@ -102,8 +102,7 @@ public abstract class AbstractLifecycleEventLoop extends AbstractCloseable imple
      */
     protected abstract void performStopFromStarted();
 
-    @Deprecated
-    public final void awaitTermination() {
+    protected final void awaitTermination() {
         long endTime = System.currentTimeMillis() + AWAIT_TERMINATION_TIMEOUT_MS;
         while (!Thread.currentThread().isInterrupted()) {
             if (lifecycle.get() == EventLoopLifecycle.STOPPED)


### PR DESCRIPTION
We seem to be leaving deprecated methods visible, I think it'd be good to reduce visibility as much as possible while we're doing the breaking changes, so we don't have to do it again later.