### PR TITLE
Ensure that disk space monitor runs for more than one iteration

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/DiskSpaceMonitor.java
+++ b/src/main/java/net/openhft/chronicle/threads/DiskSpaceMonitor.java
@@ -18,6 +18,9 @@
 package net.openhft.chronicle.threads;
 
 import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.time.SystemTimeProvider;
+import net.openhft.chronicle.core.time.TimeProvider;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.io.Closeable;
 import java.io.File;
@@ -46,6 +49,7 @@ public enum DiskSpaceMonitor implements Runnable, Closeable {
     final Map<FileStore, DiskAttributes> diskAttributesMap = new ConcurrentHashMap<>();
     final ScheduledExecutorService executor;
     private int thresholdPercentage = Jvm.getInteger("chronicle.disk.monitor.threshold.percent", 0);
+    private TimeProvider timeProvider = SystemTimeProvider.INSTANCE;
 
     DiskSpaceMonitor() {
         if (!Jvm.getBoolean("chronicle.disk.monitor.disable")) {
@@ -74,7 +78,7 @@ public enum DiskSpaceMonitor implements Runnable, Closeable {
     public void pollDiskSpace(File file) {
         if (DISABLED)
             return;
-        long start = System.nanoTime();
+        long start = timeProvider.currentTimeNanos();
 
         final String absolutePath = file.getAbsolutePath();
         FileStore fs = fileStoreCacheMap.get(absolutePath);
@@ -95,9 +99,8 @@ public enum DiskSpaceMonitor implements Runnable, Closeable {
             }
         }
         DiskAttributes da = diskAttributesMap.computeIfAbsent(fs, DiskAttributes::new);
-        da.polled = true;
 
-        final long tookUs = (System.nanoTime() - start) / 1_000;
+        final long tookUs = (timeProvider.currentTimeNanos() - start) / 1_000;
         if (tookUs > TIME_TAKEN_WARN_THRESHOLD_US)
             Jvm.perf().on(getClass(), "Took " + tookUs / 1000.0 + " ms to pollDiskSpace for " + file.getAbsolutePath());
     }
@@ -124,6 +127,11 @@ public enum DiskSpaceMonitor implements Runnable, Closeable {
         this.thresholdPercentage = thresholdPercentage;
     }
 
+    @VisibleForTesting
+    protected void setTimeProvider(TimeProvider timeProvider) {
+        this.timeProvider = timeProvider;
+    }
+
     @Override
     public void close() {
         if (executor != null)
@@ -134,7 +142,6 @@ public enum DiskSpaceMonitor implements Runnable, Closeable {
 
         private final FileStore fileStore;
 
-        volatile boolean polled;
         long timeNextCheckedMS;
         long totalSpace;
 
@@ -143,11 +150,10 @@ public enum DiskSpaceMonitor implements Runnable, Closeable {
         }
 
         void run() throws IOException {
-            long now = System.currentTimeMillis();
-            if (timeNextCheckedMS > now || !polled)
+            long now = timeProvider.currentTimeMillis();
+            if (timeNextCheckedMS > now)
                 return;
 
-            polled = false;
             long start = System.nanoTime();
             if (totalSpace <= 0)
                 totalSpace = fileStore.getTotalSpace();

--- a/src/test/java/net/openhft/chronicle/threads/DiskSpaceMonitorTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/DiskSpaceMonitorTest.java
@@ -20,16 +20,34 @@ package net.openhft.chronicle.threads;
 
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.onoes.ExceptionKey;
-import net.openhft.chronicle.core.onoes.LogLevel;
+import net.openhft.chronicle.core.time.SetTimeProvider;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class DiskSpaceMonitorTest extends ThreadsTestCommon {
+
+    @BeforeEach
+    public void beforeEach(){
+        clearState();
+    }
+
+    @AfterEach
+    public void afterEach(){
+        clearState();
+    }
+
+    private void clearState() {
+        DiskSpaceMonitor.INSTANCE.setThresholdPercentage(0);
+        DiskSpaceMonitor.INSTANCE.clear();
+    }
 
     @Test
     public void pollDiskSpace() {
@@ -53,4 +71,21 @@ public class DiskSpaceMonitorTest extends ThreadsTestCommon {
         // look for 5 disk space checks and some debug messages about slow disk checks.
         assertEquals(5.5, count, 1.5);
     }
+
+    /**
+     * This test was created to verify that the core monitoring loop actually runs more than once. It used to run once
+     * and then never again. This test explicitly changes the threshold after the first run has happened to ensure that
+     * a failure occurs on a subsequent run.
+     */
+    @Test
+    public void ensureThatDiskSpaceMonitorRunsForMoreThanOneIteration() throws InterruptedException {
+        SetTimeProvider timeProvider = new SetTimeProvider();
+        expectException("warning: the JVM may crash if it undertakes an operation with a memory-mapped file and the disk is out of space");
+        DiskSpaceMonitor.INSTANCE.pollDiskSpace(new File("."));
+        timeProvider.advanceMillis(1200);
+        DiskSpaceMonitor.INSTANCE.setThresholdPercentage(100);
+        timeProvider.advanceMillis(Duration.ofHours(24).toMillis());
+        Thread.sleep(1000);
+    }
+
 }


### PR DESCRIPTION
Due to the value of the `polled` variable always being false after the first iteration of the run loop, the loop would never re-evaluate.