### PR TITLE
Reset timers on every loop iteration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,16 @@
             <artifactId>chronicle-test-framework</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/net/openhft/chronicle/threads/CoreEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/CoreEventLoop.java
@@ -23,11 +23,23 @@ import org.jetbrains.annotations.NotNull;
 import java.util.function.BooleanSupplier;
 
 public interface CoreEventLoop extends EventLoop {
+
+    /**
+     * The value returned for {@link #loopStartNS()} when the event loop is not currently
+     * executing an iteration
+     */
+    long NOT_IN_A_LOOP = Long.MAX_VALUE;
+
     /**
      * @return thread that the event loop is running on. Will be null if the event loop has not started
      */
     Thread thread();
 
+    /**
+     * Get the {@link System#nanoTime()} at which the currently executing loop iteration started
+     *
+     * @return The time the current loop started, or {@link #NOT_IN_A_LOOP} if no iteration is executing
+     */
     long loopStartNS();
 
     void dumpRunningState(@NotNull final String message, @NotNull final BooleanSupplier finalCheck);

--- a/src/main/java/net/openhft/chronicle/threads/ThreadHolder.java
+++ b/src/main/java/net/openhft/chronicle/threads/ThreadHolder.java
@@ -30,6 +30,11 @@ public interface ThreadHolder {
 
     void resetTimers();
 
+    /**
+     * Get the {@link System#nanoTime()} at which the currently executing loop iteration started
+     *
+     * @return The time the current loop started, or {@link CoreEventLoop#NOT_IN_A_LOOP} if no iteration is executing
+     */
     long startedNS();
 
     boolean shouldLog(long nowNS);

--- a/src/test/java/net/openhft/chronicle/threads/internal/ThreadMonitorHarnessTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/internal/ThreadMonitorHarnessTest.java
@@ -1,0 +1,140 @@
+package net.openhft.chronicle.threads.internal;
+
+import net.openhft.chronicle.core.threads.InvalidEventHandlerException;
+import net.openhft.chronicle.threads.ThreadHolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+
+import static net.openhft.chronicle.threads.CoreEventLoop.NOT_IN_A_LOOP;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ThreadMonitorHarnessTest {
+
+    private static final long TIMING_TOLERANCE_NS = 10_000_000;
+
+    private ThreadMonitorHarness threadMonitorHarness;
+
+    @Mock
+    private ThreadHolder threadHolder;
+    @Mock
+    private LongSupplier timeSupplier;
+
+    @BeforeEach
+    void setUp() throws InvalidEventHandlerException {
+        threadMonitorHarness = new ThreadMonitorHarness(threadHolder, timeSupplier);
+        lenient().when(threadHolder.isAlive()).thenReturn(true);
+        lenient().when(threadHolder.timingToleranceNS()).thenReturn(TIMING_TOLERANCE_NS);
+        lenient().when(timeSupplier.getAsLong()).thenReturn(System.nanoTime());
+    }
+
+    @Test
+    void willCallThreadFinishedThenTerminateWhenThreadIsNoLongerAlive() throws InvalidEventHandlerException {
+        when(threadHolder.isAlive()).thenReturn(false);
+
+        assertThrows(InvalidEventHandlerException.class, () -> threadMonitorHarness.action());
+        verify(threadHolder).reportFinished();
+    }
+
+    @Test
+    void willResetTimersOnFirstIteration() throws InvalidEventHandlerException {
+        when(threadHolder.startedNS()).thenReturn(System.nanoTime());
+
+        assertFalse(threadMonitorHarness.action());
+
+        verify(threadHolder).resetTimers();
+    }
+
+    @Test
+    void willAbortCheckingWhenLoopStartedTimeIsZero() throws InvalidEventHandlerException {
+        when(threadHolder.startedNS()).thenReturn(0L);
+
+        assertFalse(threadMonitorHarness.action());
+
+        verify(threadHolder, never()).shouldLog(anyLong());
+    }
+
+    @Test
+    void willAbortCheckingWhenLoopStartedTimeIsNotInALoop() throws InvalidEventHandlerException {
+        when(threadHolder.startedNS()).thenReturn(NOT_IN_A_LOOP);
+
+        assertFalse(threadMonitorHarness.action());
+
+        verify(threadHolder, never()).shouldLog(anyLong());
+    }
+
+    @Test
+    void willResetTimersWhenLoopStartedTimeHasChanged() throws InvalidEventHandlerException {
+        AtomicLong loopStartedTime = new AtomicLong(System.nanoTime());
+        when(threadHolder.startedNS()).thenAnswer(iom -> loopStartedTime.incrementAndGet());
+
+        assertFalse(threadMonitorHarness.action());
+        assertFalse(threadMonitorHarness.action());
+        assertFalse(threadMonitorHarness.action());
+
+        verify(threadHolder, times(3)).resetTimers();
+    }
+
+    @Test
+    void willNotResetTimersWhenLoopStartedTimeHasNotChanged() throws InvalidEventHandlerException {
+        when(threadHolder.startedNS()).thenReturn(System.nanoTime());
+
+        assertFalse(threadMonitorHarness.action()); // this will trigger a reset because it's the first iteration
+        assertFalse(threadMonitorHarness.action());
+        assertFalse(threadMonitorHarness.action());
+
+        verify(threadHolder, times(1)).resetTimers();
+    }
+
+    @Test
+    void willCallMonitorThreadDelayedWhenDelayIsGreaterThanThreshold() throws InvalidEventHandlerException {
+        final long firstCallTime = System.nanoTime();
+        when(threadHolder.startedNS()).thenReturn(System.nanoTime());
+        when(timeSupplier.getAsLong()).thenReturn(firstCallTime);
+
+        // reset timers on first iteration
+        threadMonitorHarness.action();
+
+        long actionCallDelayNs = TIMING_TOLERANCE_NS + 1;
+
+        when(timeSupplier.getAsLong()).thenReturn(firstCallTime + actionCallDelayNs);
+        assertTrue(threadMonitorHarness.action());
+        verify(threadHolder).monitorThreadDelayed(actionCallDelayNs);
+    }
+
+    @Test
+    void willNotCallDumpThreadWhenShouldNotLog() throws InvalidEventHandlerException {
+        final long nowTime = System.nanoTime();
+        when(threadHolder.startedNS()).thenReturn(System.nanoTime());
+        when(timeSupplier.getAsLong()).thenReturn(nowTime);
+
+        // reset timers on first iteration
+        threadMonitorHarness.action();
+
+        when(threadHolder.shouldLog(nowTime)).thenReturn(false);
+        assertFalse(threadMonitorHarness.action());
+        verify(threadHolder, never()).dumpThread(anyLong(), anyLong());
+    }
+
+    @Test
+    void willCallDumpThreadWhenShouldLog() throws InvalidEventHandlerException {
+        final long nowTime = System.nanoTime();
+        final long loopStartedTime = System.nanoTime();
+        when(threadHolder.startedNS()).thenReturn(loopStartedTime);
+        when(timeSupplier.getAsLong()).thenReturn(nowTime);
+
+        // reset timers on first iteration
+        threadMonitorHarness.action();
+
+        when(threadHolder.shouldLog(anyLong())).thenReturn(true);
+        assertFalse(threadMonitorHarness.action());
+        verify(threadHolder).dumpThread(loopStartedTime, nowTime);
+    }
+}


### PR DESCRIPTION
Instead of resetting the timers whenever we catch the event loop between iterations, we will now perform a reset whenever we're in an iteration and it's not the same iteration that we were in last time we checked.

This guarantees that even when the handler is busy, we will continue monitoring for loop blockages, and doesn't leave the reset of the progressive back-off to chance (that we poll right at the moment the loop is between iterations).

Build-all bumped [here](https://teamcity.chronicle.software/buildConfiguration/Chronicle_BuildAll_BumpedBranch?branch=reset_timers_on_every_loop_iteration&mode=builds)