### PR TITLE
Remove old check.thread.safety property

### DIFF
--- a/system.properties
+++ b/system.properties
@@ -20,7 +20,6 @@
 jvm.resource.tracing=true
 disable.resource.warning=true
 
-check.thread.safety=true
 disable.discard.warning=false
 # for profiling
 jvm.safepoint.enabled=false


### PR DESCRIPTION
The check.thread.saftety property has not been used for a while. Removing references to it.