### PR TITLE
Ensure EventHandler loopStarted/loopFinished do not terminate MediumEventLoop

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/BlockingEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/BlockingEventLoop.java
@@ -31,8 +31,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.function.Supplier;
 
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
-import static net.openhft.chronicle.threads.Threads.loopFinishedQuietly;
-import static net.openhft.chronicle.threads.Threads.unpark;
+import static net.openhft.chronicle.threads.Threads.*;
 
 /**
  * Event Loop for blocking tasks.
@@ -77,7 +76,7 @@ public class BlockingEventLoop extends AbstractLifecycleEventLoop implements Eve
             Jvm.startup().on(getClass(), "Adding " + handler.priority() + " " + handler + " to " + this.name);
         if (isClosed())
             throw new IllegalStateException("Event Group has been closed");
-        handler.eventLoop(parent);
+        eventLoopQuietly(parent, handler);
         this.handlers.add(handler);
         if (isStarted())
             this.startHandler(handler);

--- a/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
@@ -495,7 +495,7 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
         return true;
     }
 
-    private void removeHighHandler() {
+   protected void removeHighHandler() {
         Threads.loopFinishedQuietly(highHandler);
         Closeable.closeQuietly(highHandler);
         highHandler = EventHandlers.NOOP;
@@ -585,7 +585,7 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
         }
     }
 
-    private boolean performHandlerLoopStarted(@NotNull EventHandler handler) {
+    protected boolean performHandlerLoopStarted(@NotNull EventHandler handler) {
         try {
             handler.loopStarted();
             return false;

--- a/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
@@ -38,6 +38,7 @@ import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static net.openhft.chronicle.threads.Threads.eventLoopQuietly;
 import static net.openhft.chronicle.threads.Threads.loopFinishedQuietly;
 
 public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreEventLoop, Runnable, Closeable {
@@ -600,7 +601,7 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
      */
     protected boolean updateHighHandler(@NotNull EventHandler handler) {
         if (highHandler == EventHandlers.NOOP || highHandler == handler) {
-            handler.eventLoop(parent != null ? parent : this);
+            eventLoopQuietly(parent != null ? parent : this, handler);
             highHandler = handler;
             return true;
         }

--- a/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
@@ -281,8 +281,13 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
             removeHighHandler();
         }
 
+        loopStartedForHandlerList(mediumHandlers);
+        updateMediumHandlersArray();
+    }
+
+    protected void loopStartedForHandlerList(@NotNull List<EventHandler> eventHandlerList) {
         List<EventHandler> removeHandlers = new ArrayList<>();
-        for (EventHandler handler : mediumHandlers) {
+        for (EventHandler handler : eventHandlerList) {
             if (performHandlerLoopStarted(handler)) {
                 // iterator.remove() is not supported.
                 removeHandlers.add(handler);
@@ -291,9 +296,8 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
 
         // Remove handlers that had exception in loopStarted.
         for (EventHandler handler : removeHandlers) {
-            removeHandler(handler, mediumHandlers);
+            removeHandler(handler, eventHandlerList);
         }
-        updateMediumHandlersArray();
     }
 
     protected void loopFinishedAllHandlers() {

--- a/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
@@ -38,8 +38,7 @@ import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static net.openhft.chronicle.threads.Threads.eventLoopQuietly;
-import static net.openhft.chronicle.threads.Threads.loopFinishedQuietly;
+import static net.openhft.chronicle.threads.Threads.*;
 
 public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreEventLoop, Runnable, Closeable {
     public static final Set<HandlerPriority> ALLOWED_PRIORITIES =
@@ -277,7 +276,7 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
     }
 
     protected void loopStartedAllHandlers() {
-        if (performHandlerLoopStarted(highHandler)) {
+        if (loopStartedCall(this, highHandler)) {
             removeHighHandler();
         }
 
@@ -288,7 +287,7 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
     protected void loopStartedForHandlerList(@NotNull List<EventHandler> eventHandlerList) {
         List<EventHandler> removeHandlers = new ArrayList<>();
         for (EventHandler handler : eventHandlerList) {
-            if (performHandlerLoopStarted(handler)) {
+            if (loopStartedCall(this, handler)) {
                 // iterator.remove() is not supported.
                 removeHandlers.add(handler);
             }
@@ -579,7 +578,7 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
         }
 
         if (thread == Thread.currentThread()) {
-            if (performHandlerLoopStarted(handler)) {
+            if (loopStartedCall(this, handler)) {
                 if (handler == this.highHandler) {
                     removeHighHandler();
                 } else {
@@ -587,16 +586,6 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
                     updateMediumHandlersArray();
                 }
             }
-        }
-    }
-
-    protected boolean performHandlerLoopStarted(@NotNull EventHandler handler) {
-        try {
-            handler.loopStarted();
-            return false;
-        } catch (Throwable t) {
-            Jvm.warn().on(getClass(), "EventHandler::loopStarted exception. Removing handler", t);
-            return true;
         }
     }
 

--- a/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
@@ -584,16 +584,6 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
         }
     }
 
-    private boolean performHandlerLoopFinished(@NotNull EventHandler handler) {
-        try {
-            handler.loopFinished();
-            return false;
-        } catch (Throwable t) {
-            Jvm.warn().on(getClass(), "EventHandler::loopFinished exception.", t);
-            return true;
-        }
-    }
-
     private boolean performHandlerLoopStarted(@NotNull EventHandler handler) {
         try {
             handler.loopStarted();

--- a/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
@@ -111,14 +111,15 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
     }
 
     protected static void removeHandler(final EventHandler handler, @NotNull final List<EventHandler> handlers) {
+        // Close the handler before removing it from the list
+        loopFinishedQuietly(handler);
+        Closeable.closeQuietly(handler);
         try {
             handlers.remove(handler);
         } catch (ArrayIndexOutOfBoundsException e2) {
             if (!handlers.isEmpty())
                 throw e2;
         }
-        loopFinishedQuietly(handler);
-        Closeable.closeQuietly(handler);
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
@@ -495,9 +495,9 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
     }
 
     private void removeHighHandler() {
-        highHandler = EventHandlers.NOOP;
         Threads.loopFinishedQuietly(highHandler);
         Closeable.closeQuietly(highHandler);
+        highHandler = EventHandlers.NOOP;
     }
 
     private void handleExceptionMediumHandler(EventHandler handler, Throwable t) {

--- a/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
@@ -270,13 +270,16 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
             }
         } catch (Throwable e) {
             Jvm.warn().on(getClass(), hasBeen("terminated due to exception"), e);
+            stop();
         }
     }
 
     protected void loopStartedAllHandlers() {
         highHandler.loopStarted();
         if (!mediumHandlers.isEmpty())
-            mediumHandlers.forEach(EventHandler::loopStarted);
+            mediumHandlers.forEach(
+                    EventHandler::loopStarted
+            );
     }
 
     protected void loopFinishedAllHandlers() {
@@ -552,8 +555,13 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
             default:
                 throw new IllegalArgumentException("Cannot add a " + handler.priority() + " task to a busy waiting thread");
         }
-        if (thread == Thread.currentThread())
-            handler.loopStarted();
+        if (thread == Thread.currentThread()) {
+            try {
+                handler.loopStarted();
+            } catch (Throwable t) {
+                handleExceptionMediumHandler(handler, t);
+            }
+        }
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
@@ -495,9 +495,9 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
     }
 
     private void removeHighHandler() {
+        highHandler = EventHandlers.NOOP;
         Threads.loopFinishedQuietly(highHandler);
         Closeable.closeQuietly(highHandler);
-        highHandler = EventHandlers.NOOP;
     }
 
     private void handleExceptionMediumHandler(EventHandler handler, Throwable t) {

--- a/src/main/java/net/openhft/chronicle/threads/MonitorEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MonitorEventLoop.java
@@ -131,7 +131,7 @@ public class MonitorEventLoop extends AbstractLifecycleEventLoop implements Runn
         for (int i = 0; i < handlers.size(); i++) {
             final EventHandler handler = handlers.get(i);
             try {
-                if (loopStartedCall(getClass(), handler)) {
+                if (loopStartedCall(this, handler)) {
                     removeHandler(i--);
                     continue;
                 }

--- a/src/main/java/net/openhft/chronicle/threads/MonitorEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MonitorEventLoop.java
@@ -32,6 +32,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static net.openhft.chronicle.threads.Threads.*;
+
 public class MonitorEventLoop extends AbstractLifecycleEventLoop implements Runnable, EventLoop {
     public static final String MONITOR_INITIAL_DELAY = "MonitorInitialDelay";
     static int MONITOR_INITIAL_DELAY_MS = Jvm.getInteger(MONITOR_INITIAL_DELAY, 10_000);
@@ -91,7 +93,7 @@ public class MonitorEventLoop extends AbstractLifecycleEventLoop implements Runn
             Jvm.startup().on(getClass(), "Adding " + handler.priority() + " " + handler + " to " + this.name);
         if (isClosed())
             throw new IllegalStateException("Event Group has been closed");
-        handler.eventLoop(parent);
+        eventLoopQuietly(parent, handler);
         if (!handlers.contains(handler))
             handlers.add(new IdempotentLoopStartedEventHandler(handler));
     }
@@ -128,14 +130,16 @@ public class MonitorEventLoop extends AbstractLifecycleEventLoop implements Runn
         boolean busy = false;
         for (int i = 0; i < handlers.size(); i++) {
             final EventHandler handler = handlers.get(i);
-            handler.loopStarted();
             try {
+                if (loopStartedCall(getClass(), handler)) {
+                    removeHandler(i--);
+                    continue;
+                }
                 busy |= handler.action();
-
             } catch (InvalidEventHandlerException e) {
                 removeHandler(i--);
             } catch (Exception e) {
-                Jvm.warn().on(getClass(), "Loop terminated due to exception", e);
+                Jvm.warn().on(getClass(), "Exception thrown by handler " + handler, e);
                 removeHandler(i--);
             }
         }
@@ -145,7 +149,7 @@ public class MonitorEventLoop extends AbstractLifecycleEventLoop implements Runn
     private synchronized void removeHandler(int handlerIndex) {
         try {
             EventHandler removedHandler = handlers.remove(handlerIndex);
-            removedHandler.loopFinished();
+            loopFinishedQuietly(removedHandler);
             Closeable.closeQuietly(removedHandler);
         } catch (ArrayIndexOutOfBoundsException e) {
             if (!handlers.isEmpty()) {

--- a/src/main/java/net/openhft/chronicle/threads/Threads.java
+++ b/src/main/java/net/openhft/chronicle/threads/Threads.java
@@ -18,10 +18,9 @@
 package net.openhft.chronicle.threads;
 
 import net.openhft.chronicle.core.Jvm;
-import net.openhft.chronicle.core.annotation.ForceInline;
 import net.openhft.chronicle.core.threads.EventHandler;
+import net.openhft.chronicle.core.threads.EventLoop;
 import net.openhft.chronicle.core.util.ObjectUtils;
-import net.openhft.chronicle.core.util.ThrowingCallable;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.Thread.State;
@@ -241,6 +240,24 @@ public enum Threads {
             // We can't access the field, move on
         }
         return executorService;
+    }
+
+    static void eventLoopQuietly(EventLoop eventLoop, @NotNull EventHandler handler) {
+        try {
+            handler.eventLoop(eventLoop);
+        } catch (Throwable t) {
+            Jvm.warn().on(eventLoop.getClass(), "EventHandler::eventLoop exception", t);
+        }
+    }
+
+    static boolean loopStartedCall(Class<?> eventLoopClass, @NotNull EventHandler handler) {
+        try {
+            handler.loopStarted();
+            return false;
+        } catch (Throwable t) {
+            Jvm.warn().on(eventLoopClass, "EventHandler::loopStarted exception. Removing handler", t);
+            return true;
+        }
     }
 
     static void loopFinishedQuietly(EventHandler eventHandler) {

--- a/src/main/java/net/openhft/chronicle/threads/Threads.java
+++ b/src/main/java/net/openhft/chronicle/threads/Threads.java
@@ -250,12 +250,12 @@ public enum Threads {
         }
     }
 
-    static boolean loopStartedCall(Class<?> eventLoopClass, @NotNull EventHandler handler) {
+    static boolean loopStartedCall(EventLoop eventLoop, @NotNull EventHandler handler) {
         try {
             handler.loopStarted();
             return false;
         } catch (Throwable t) {
-            Jvm.warn().on(eventLoopClass, "EventHandler::loopStarted exception. Removing handler", t);
+            Jvm.warn().on(eventLoop.getClass(), "EventHandler::loopStarted exception. Removing handler", t);
             return true;
         }
     }

--- a/src/main/java/net/openhft/chronicle/threads/VanillaEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/VanillaEventLoop.java
@@ -107,30 +107,8 @@ public class VanillaEventLoop extends MediumEventLoop {
     @Override
     protected void loopStartedAllHandlers() {
         super.loopStartedAllHandlers();
-
-        List<EventHandler> removeHandlers = new ArrayList<>();
-        for (EventHandler handler: timerHandlers) {
-            if (performHandlerLoopStarted(handler)) {
-                removeHandlers.add(handler);
-            }
-        }
-
-        // Remove handlers that had exception in loopStarted.
-        for (EventHandler handler : removeHandlers) {
-            removeHandler(handler, timerHandlers);
-        }
-
-        removeHandlers.clear();
-        for (EventHandler handler: daemonHandlers) {
-            if (performHandlerLoopStarted(handler)) {
-                removeHandlers.add(handler);
-            }
-        }
-
-        // Remove handlers that had exception in loopStarted.
-        for (EventHandler handler : removeHandlers) {
-            removeHandler(handler, daemonHandlers);
-        }
+        loopStartedForHandlerList(timerHandlers);
+        loopStartedForHandlerList(daemonHandlers);
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/threads/VanillaEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/VanillaEventLoop.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static net.openhft.chronicle.threads.Threads.eventLoopQuietly;
+import static net.openhft.chronicle.threads.Threads.loopStartedCall;
 
 public class VanillaEventLoop extends MediumEventLoop {
     public static final Set<HandlerPriority> ALLOWED_PRIORITIES =
@@ -194,7 +195,7 @@ public class VanillaEventLoop extends MediumEventLoop {
         }
 
         if (thread == Thread.currentThread()) {
-            if (performHandlerLoopStarted(handler)) {
+            if (loopStartedCall(this, handler)) {
                 if (handler == this.highHandler) {
                     removeHighHandler();
                 } else {

--- a/src/test/java/net/openhft/chronicle/threads/EventGroupHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventGroupHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2024 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/threads/EventGroupHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventGroupHandlerTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.*;
 import static net.openhft.chronicle.threads.TestEventHandlers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class EventGroupHandlerTest extends ThreadsTestCommon {
+class EventGroupHandlerTest extends ThreadsTestCommon {
 
     @BeforeEach
     public void beforeAll() {
@@ -44,7 +44,7 @@ public class EventGroupHandlerTest extends ThreadsTestCommon {
         return EventGroup.builder().withName(EVENT_GROUP_NAME).withDaemon(true).build();
     }
 
-    public void addGoodHandlerBeforeStart(CountingHandler handler) {
+    void addGoodHandlerBeforeStart(CountingHandler handler) {
 
         try (final EventLoop eventGroup = createEventGroup()) {
             assertEquals(EVENT_GROUP_NAME, eventGroup.name());
@@ -81,7 +81,7 @@ public class EventGroupHandlerTest extends ThreadsTestCommon {
     }
 
     @Test
-    public void testGoodHandlerAddedBeforeStart() {
+    void testGoodHandlerAddedBeforeStart() {
         for(HandlerPriority priority : HandlerPriority.values()) {
             addGoodHandlerBeforeStart(new CountingHandler(priority));
         }
@@ -123,7 +123,7 @@ public class EventGroupHandlerTest extends ThreadsTestCommon {
     }
 
     @Test
-    public void testGoodHandlerAddedAfterStart() {
+    void testGoodHandlerAddedAfterStart() {
         for(HandlerPriority priority : HandlerPriority.values()) {
             addGoodHandlerAfterStart(new CountingHandler(priority));
         }
@@ -166,37 +166,37 @@ public class EventGroupHandlerTest extends ThreadsTestCommon {
     // ExpectException does not like looping through the test case. Using individual test cases.
 
     @Test
-    public void testThrowingHandlerAddedBeforeStartMonitor() {
+    void testThrowingHandlerAddedBeforeStartMonitor() {
         addThrowingHandlerLoopStartedBeforeStart(new ThrowingHandler(HandlerPriority.MONITOR, false, false));
     }
 
     @Test
-    public void testThrowingHandlerAddedBeforeStartHigh() {
+    void testThrowingHandlerAddedBeforeStartHigh() {
         addThrowingHandlerLoopStartedBeforeStart(new ThrowingHandler(HandlerPriority.HIGH, false, false));
     }
 
     @Test
-    public void testThrowingHandlerAddedBeforeStartMedium() {
+    void testThrowingHandlerAddedBeforeStartMedium() {
         addThrowingHandlerLoopStartedBeforeStart(new ThrowingHandler(HandlerPriority.MEDIUM, false, false));
     }
 
     @Test
-    public void testThrowingHandlerAddedBeforeStartTimer() {
+    void testThrowingHandlerAddedBeforeStartTimer() {
         addThrowingHandlerLoopStartedBeforeStart(new ThrowingHandler(HandlerPriority.TIMER, false, false));
     }
 
     @Test
-    public void testThrowingHandlerAddedBeforeStartDaemon() {
+    void testThrowingHandlerAddedBeforeStartDaemon() {
         addThrowingHandlerLoopStartedBeforeStart(new ThrowingHandler(HandlerPriority.DAEMON, false, false));
     }
 
     @Test
-    public void testThrowingHandlerAddedBeforeStartBlocking() {
+    void testThrowingHandlerAddedBeforeStartBlocking() {
         addThrowingHandlerLoopStartedBeforeStart(new ThrowingHandler(HandlerPriority.BLOCKING, false, false));
     }
 
     @Test
-    public void testThrowingHandlerAddedBeforeStartConcurrent() {
+    void testThrowingHandlerAddedBeforeStartConcurrent() {
         addThrowingHandlerLoopStartedBeforeStart(new ThrowingHandler(HandlerPriority.CONCURRENT, false, false));
     }
 
@@ -227,37 +227,37 @@ public class EventGroupHandlerTest extends ThreadsTestCommon {
     }
 
     @Test
-    public void testThrowingHandlerAddedAfterStartMonitor() {
+    void testThrowingHandlerAddedAfterStartMonitor() {
         addThrowingHandlerAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.MONITOR, false, false));
     }
 
     @Test
-    public void testThrowingHandlerAddedAfterStartHigh() {
+    void testThrowingHandlerAddedAfterStartHigh() {
         addThrowingHandlerAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.HIGH, false, false));
     }
 
     @Test
-    public void testThrowingHandlerAddedAfterStartMedium() {
+    void testThrowingHandlerAddedAfterStartMedium() {
         addThrowingHandlerAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.MEDIUM, false, false));
     }
 
     @Test
-    public void testThrowingHandlerAddedAfterStartTimer() {
+    void testThrowingHandlerAddedAfterStartTimer() {
         addThrowingHandlerAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.TIMER, false, false));
     }
 
     @Test
-    public void testThrowingHandlerAddedAfterStartDaemon() {
+    void testThrowingHandlerAddedAfterStartDaemon() {
         addThrowingHandlerAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.DAEMON, false, false));
     }
 
     @Test
-    public void testThrowingHandlerAddedAfterStartBlocking() {
+    void testThrowingHandlerAddedAfterStartBlocking() {
         addThrowingHandlerAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.BLOCKING, false, false));
     }
 
     @Test
-    public void testThrowingHandlerAddedAfterStartConcurrent() {
+    void testThrowingHandlerAddedAfterStartConcurrent() {
         addThrowingHandlerAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.CONCURRENT, false, false));
     }
 
@@ -298,37 +298,37 @@ public class EventGroupHandlerTest extends ThreadsTestCommon {
     }
 
     @Test
-    public void testThrowingEventLoopAddedAfterStartMonitor() {
+    void testThrowingEventLoopAddedAfterStartMonitor() {
         addThrowingEventLoopAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.MONITOR, true, false));
     }
 
     @Test
-    public void testThrowingEventLoopAddedAfterStartHigh() {
+    void testThrowingEventLoopAddedAfterStartHigh() {
         addThrowingEventLoopAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.HIGH, true, false));
     }
 
     @Test
-    public void testThrowingEventLoopAddedAfterStartMedium() {
+    void testThrowingEventLoopAddedAfterStartMedium() {
         addThrowingEventLoopAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.MEDIUM, true, false));
     }
 
     @Test
-    public void testThrowingEventLoopAddedAfterStartTimer() {
+    void testThrowingEventLoopAddedAfterStartTimer() {
         addThrowingEventLoopAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.TIMER, true, false));
     }
 
     @Test
-    public void testThrowingEventLoopAddedAfterStartDaemon() {
+    void testThrowingEventLoopAddedAfterStartDaemon() {
         addThrowingEventLoopAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.DAEMON, true, false));
     }
 
     @Test
-    public void testThrowingEventLoopAddedAfterStartBlocking() {
+    void testThrowingEventLoopAddedAfterStartBlocking() {
         addThrowingEventLoopAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.BLOCKING, true, false));
     }
 
     @Test
-    public void testThrowingEventLoopAddedAfterStartConcurrent() {
+    void testThrowingEventLoopAddedAfterStartConcurrent() {
         addThrowingEventLoopAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.CONCURRENT, true, false));
     }
 

--- a/src/test/java/net/openhft/chronicle/threads/EventGroupHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventGroupHandlerTest.java
@@ -33,8 +33,8 @@ public class EventGroupHandlerTest extends ThreadsTestCommon {
         MonitorEventLoop.MONITOR_INITIAL_DELAY_MS = 10;
     }
 
-    @BeforeEach
-    public void afterAll() {
+    @AfterEach
+    public void afterEach() {
         MonitorEventLoop.MONITOR_INITIAL_DELAY_MS = 10_000;
     }
 

--- a/src/test/java/net/openhft/chronicle/threads/EventGroupHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventGroupHandlerTest.java
@@ -26,14 +26,15 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class EventGroupHandlerTest extends ThreadsTestCommon {
 
-    @BeforeAll
-    public static void beforeAll() {
+    @BeforeEach
+    public void beforeAll() {
+        ignoreException("Monitoring a task which has finished ");
         // Initial delay defaults to 10secs. Set to 10ms for testing.
         MonitorEventLoop.MONITOR_INITIAL_DELAY_MS = 10;
     }
 
-    @AfterAll
-    public static void afterAll() {
+    @BeforeEach
+    public void afterAll() {
         MonitorEventLoop.MONITOR_INITIAL_DELAY_MS = 10_000;
     }
 

--- a/src/test/java/net/openhft/chronicle/threads/EventGroupTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventGroupTest.java
@@ -217,6 +217,7 @@ public class EventGroupTest extends ThreadsTestCommon {
             eventGroup.stop();
             handlers.forEach(testHandler -> assertFalse(testHandler.isClosing()));
         }
+        handlers.forEach(testHandler -> assertTrue(testHandler.isClosed()));
     }
 
     @Timeout(5)

--- a/src/test/java/net/openhft/chronicle/threads/EventGroupThrowingHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventGroupThrowingHandlerTest.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2016-2020 chronicle.software
+ *
+ *       https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.threads;
+
+import net.openhft.chronicle.core.threads.*;
+import net.openhft.chronicle.testframework.Waiters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static net.openhft.chronicle.threads.MonitorEventLoop.MONITOR_INITIAL_DELAY;
+import static net.openhft.chronicle.threads.TestEventHandlers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EventGroupThrowingHandlerTest extends ThreadsTestCommon {
+
+    @BeforeEach
+    public void handlersInit() {
+        // Initial delay defaults to 10secs. Set to 10ms for testing.
+        System.setProperty(MONITOR_INITIAL_DELAY, "10");
+    }
+
+    private final String EVENT_GROUP_NAME = "test";
+
+    private EventGroup createEventGroup() {
+        return EventGroup.builder().withName(EVENT_GROUP_NAME).withDaemon(true).build();
+    }
+
+    public void addGoodHandlerBeforeStart(CountingHandler handler) {
+
+        try (final EventLoop eventGroup = createEventGroup()) {
+            assertEquals(EVENT_GROUP_NAME, eventGroup.name());
+
+            // Add the handler.
+            eventGroup.addHandler(handler);
+
+            // Start the loop.
+            eventGroup.start();
+            Waiters.waitForCondition("Wait for eventGroup started", eventGroup::isAlive, 5000);
+            Waiters.waitForCondition("Wait for handler loopStarted called:" + handler.priority, () -> (handler.loopStartedCalled() > 0), 5000);
+
+            // Check the handler.
+            assertEquals(1, handler.loopStartedCalled());
+            assertEquals(0, handler.loopFinishedCalled());
+            assertEquals(0, handler.closeCalled());
+            assertNotNull(handler.eventLoop());
+
+            // Stop the loop.
+            eventGroup.stop();
+            Waiters.waitForCondition("Wait for eventGroup stopped", eventGroup::isStopped, 5000);
+
+            // Check the handler.
+            assertEquals(1, handler.loopStartedCalled());
+            assertEquals(1, handler.loopFinishedCalled());
+            assertEquals(0, handler.closeCalled());
+        }
+
+        // Check the handler.
+        assertEquals(1, handler.loopStartedCalled());
+        assertEquals(1, handler.loopFinishedCalled());
+        assertEquals(1, handler.closeCalled());
+    }
+
+    @Test
+    public void testGoodHandlerAddedBeforeStart() {
+
+        //addGoodHandlerBeforeStart(new CountingHandler(HandlerPriority.MONITOR));
+
+        for(HandlerPriority priority : HandlerPriority.values()) {
+            addGoodHandlerBeforeStart(new CountingHandler(priority));
+        }
+    }
+
+    void addGoodHandlerAfterStart(CountingHandler handler) {
+        try (final EventLoop eventGroup = createEventGroup()) {
+
+            // Start the loop.
+            eventGroup.start();
+            Waiters.waitForCondition("Wait for loop started:" + handler.priority, eventGroup::isAlive, 5000);
+
+            // Add the handler.
+            eventGroup.addHandler(handler);
+
+            Waiters.waitForCondition("Wait handler loopStarted called:" + handler.priority,() -> (handler.loopStartedCalled() > 0), 5000);
+
+            // Check the handler.
+            assertEquals(1, handler.loopStartedCalled());
+            assertEquals(0, handler.loopFinishedCalled());
+            assertEquals(0, handler.closeCalled());
+            assertNotNull(handler.eventLoop());
+
+            // Stop the loop.
+            eventGroup.stop();
+            Waiters.waitForCondition("Wait for loop stopped:" + handler.priority, eventGroup::isStopped, 5000);
+
+            // Check the handler.
+            assertEquals(1, handler.loopStartedCalled());
+            assertEquals(1, handler.loopFinishedCalled());
+            assertEquals(0, handler.closeCalled());
+        }
+
+        // Check the handler.
+        assertEquals(1, handler.loopStartedCalled());
+        assertEquals(1, handler.loopFinishedCalled());
+        assertEquals(1, handler.closeCalled());
+    }
+
+    @Test
+    public void testGoodHandlerAddedAfterStart() {
+        for(HandlerPriority priority : HandlerPriority.values()) {
+            addGoodHandlerAfterStart(new CountingHandler(priority));
+        }
+    }
+
+    void addThrowingHandlerLoopStartedBeforeStart(CountingHandler handler) {
+        try (final EventLoop eventGroup = createEventGroup()) {
+            expectException(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
+            expectException(HANDLER_LOOP_FINISHED_EXCEPTION_TXT);
+            expectException(HANDLER_CLOSE_EXCEPTION_TXT);
+
+            // Add handler before loop has started. loopStarted not called yet.
+            eventGroup.addHandler(handler);
+
+            // Start the loop. loopStarted called and exception thrown. Expect handler to be removed.
+            eventGroup.start();
+
+            // Wait for loop to start and handler to be removed.
+            Waiters.waitForCondition("Wait for loop started:" + handler.priority, eventGroup::isAlive, 5000);
+            Waiters.waitForCondition("Wait for handler close called:" + handler.priority, () -> (handler.closeCalled() > 0), 5000);
+            //Waiters.waitForCondition("Handler should be removed", () -> (eventLoop.handlerCount() == 0), 5000);
+
+            assertTrue(eventGroup.isAlive());
+            //assertTrue(eventGroup.newHandlers.isEmpty());
+
+            // Exceptions should be thrown.
+            assertExceptionThrown(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
+            assertExceptionThrown(HANDLER_LOOP_FINISHED_EXCEPTION_TXT);
+            assertExceptionThrown(HANDLER_CLOSE_EXCEPTION_TXT);
+
+            // Methods called once.
+            assertEquals(1, handler.loopStartedCalled());
+            assertEquals(1, handler.loopFinishedCalled());
+            assertEquals(1, handler.closeCalled());
+
+            // Handler has been removed.
+            //assertEquals(0, eventGroup.handlerCount());
+
+            // Event loop is running.
+            // Expect the eventLoop to continue.
+            assertTrue(eventGroup.isAlive());
+            assertFalse(eventGroup.isStopped());
+            assertFalse(eventGroup.isClosing());
+            assertFalse(eventGroup.isClosed());
+        }
+    }
+
+    // ExpectException does not like looping through the test case. Using individual test cases.
+
+    @Test
+    public void testThrowingHandlerAddedBeforeStartMonitor() {
+        addThrowingHandlerLoopStartedBeforeStart(new ThrowingHandler(HandlerPriority.MONITOR, false, false));
+    }
+
+    @Test
+    public void testThrowingHandlerAddedBeforeStartHigh() {
+        addThrowingHandlerLoopStartedBeforeStart(new ThrowingHandler(HandlerPriority.HIGH, false, false));
+    }
+
+    @Test
+    public void testThrowingHandlerAddedBeforeStartMedium() {
+        addThrowingHandlerLoopStartedBeforeStart(new ThrowingHandler(HandlerPriority.MEDIUM, false, false));
+    }
+
+    @Test
+    public void testThrowingHandlerAddedBeforeStartTimer() {
+        addThrowingHandlerLoopStartedBeforeStart(new ThrowingHandler(HandlerPriority.TIMER, false, false));
+    }
+
+    @Test
+    public void testThrowingHandlerAddedBeforeStartDaemon() {
+        addThrowingHandlerLoopStartedBeforeStart(new ThrowingHandler(HandlerPriority.DAEMON, false, false));
+    }
+
+    @Test
+    public void testThrowingHandlerAddedBeforeStartBlocking() {
+        addThrowingHandlerLoopStartedBeforeStart(new ThrowingHandler(HandlerPriority.BLOCKING, false, false));
+    }
+
+    @Test
+    public void testThrowingHandlerAddedBeforeStartConcurrent() {
+        addThrowingHandlerLoopStartedBeforeStart(new ThrowingHandler(HandlerPriority.CONCURRENT, false, false));
+    }
+
+    void addThrowingHandlerAfterEventLoopStarted(CountingHandler handler) {
+        try (final EventLoop eventGroup = createEventGroup()) {
+            expectException(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
+            expectException(HANDLER_LOOP_FINISHED_EXCEPTION_TXT);
+            expectException(HANDLER_CLOSE_EXCEPTION_TXT);
+
+            // start the event loop with no handlers.
+            eventGroup.start();
+
+            // Wait for the handler to be started.
+            Waiters.waitForCondition("Event loop started", eventGroup::isAlive, 5000);
+
+            // Add the new handler. It should be picked up by the event loop and removed after exception in loopStarted.
+            eventGroup.addHandler(handler);
+
+            // Wait for the handler to be removed.
+            Waiters.waitForCondition("Wait handler loopStarted called:" + handler.priority,() -> (handler.closeCalled() > 0), 5000);
+
+            // Event loop is running.
+            assertTrue(eventGroup.isAlive());
+            assertFalse(eventGroup.isStopped());
+            assertFalse(eventGroup.isClosing());
+            assertFalse(eventGroup.isClosed());
+        }
+    }
+
+    @Test
+    public void testThrowingHandlerAddedAfterStartMonitor() {
+        addThrowingHandlerAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.MONITOR, false, false));
+    }
+
+    @Test
+    public void testThrowingHandlerAddedAfterStartHigh() {
+        addThrowingHandlerAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.HIGH, false, false));
+    }
+
+    @Test
+    public void testThrowingHandlerAddedAfterStartMedium() {
+        addThrowingHandlerAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.MEDIUM, false, false));
+    }
+
+    @Test
+    public void testThrowingHandlerAddedAfterStartTimer() {
+        addThrowingHandlerAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.TIMER, false, false));
+    }
+
+    @Test
+    public void testThrowingHandlerAddedAfterStartDaemon() {
+        addThrowingHandlerAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.DAEMON, false, false));
+    }
+
+    @Test
+    public void testThrowingHandlerAddedAfterStartBlocking() {
+        addThrowingHandlerAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.BLOCKING, false, false));
+    }
+
+    @Test
+    public void testThrowingHandlerAddedAfterStartConcurrent() {
+        addThrowingHandlerAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.CONCURRENT, false, false));
+    }
+
+    void addThrowingEventLoopAfterEventLoopStarted(CountingHandler handler) {
+        try (final EventLoop eventGroup = createEventGroup()) {
+            expectException(HANDLER_EVENT_LOOP_EXCEPTION_TXT);
+
+            // start the event loop with no handlers.
+            eventGroup.start();
+
+            // Wait for the handler to be started.
+            Waiters.waitForCondition("Event loop started", eventGroup::isAlive, 5000);
+
+            // Add the new handler. It should be picked up by the event loop and exception in eventLoop logged and ignored.
+            eventGroup.addHandler(handler);
+            Waiters.waitForCondition("Wait handler loopStarted called:" + handler.priority,() -> (handler.loopStartedCalled() > 0), 5000);
+
+            // Check the handler.
+            assertEquals(1, handler.loopStartedCalled());
+            assertEquals(0, handler.loopFinishedCalled());
+            assertEquals(0, handler.closeCalled());
+            assertNotNull(handler.eventLoop());
+
+            // Stop the loop.
+            eventGroup.stop();
+            Waiters.waitForCondition("Wait for loop stopped:" + handler.priority, eventGroup::isStopped, 5000);
+
+            // Check the handler.
+            assertEquals(1, handler.loopStartedCalled());
+            assertEquals(1, handler.loopFinishedCalled());
+            assertEquals(0, handler.closeCalled());
+        }
+
+        // Check the handler.
+        assertEquals(1, handler.loopStartedCalled());
+        assertEquals(1, handler.loopFinishedCalled());
+        assertEquals(1, handler.closeCalled());
+    }
+
+    @Test
+    public void testThrowingEventLoopAddedAfterStartMonitor() {
+        addThrowingEventLoopAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.MONITOR, true, false));
+    }
+
+    @Test
+    public void testThrowingEventLoopAddedAfterStartHigh() {
+        addThrowingEventLoopAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.HIGH, true, false));
+    }
+
+    @Test
+    public void testThrowingEventLoopAddedAfterStartMedium() {
+        addThrowingEventLoopAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.MEDIUM, true, false));
+    }
+
+    @Test
+    public void testThrowingEventLoopAddedAfterStartTimer() {
+        addThrowingEventLoopAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.TIMER, true, false));
+    }
+
+    @Test
+    public void testThrowingEventLoopAddedAfterStartDaemon() {
+        addThrowingEventLoopAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.DAEMON, true, false));
+    }
+
+    @Test
+    public void testThrowingEventLoopAddedAfterStartBlocking() {
+        addThrowingEventLoopAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.BLOCKING, true, false));
+    }
+
+    @Test
+    public void testThrowingEventLoopAddedAfterStartConcurrent() {
+        addThrowingEventLoopAfterEventLoopStarted(new ThrowingHandler(HandlerPriority.CONCURRENT, true, false));
+    }
+
+}

--- a/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2024 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
@@ -219,7 +219,6 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             assertEquals(1, loopStartedCalled.get());
             assertEquals(1, loopFinishedCalled.get());
             assertEquals(0, closeCalled.get());
-            //assertNull(handler.eventLoop());
         }
 
         // Check the handler.
@@ -256,7 +255,6 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             assertEquals(1, loopStartedCalled.get());
             assertEquals(1, loopFinishedCalled.get());
             assertEquals(0, closeCalled.get());
-            //assertNull(handler.eventLoop());
         }
 
         // Check the handler.
@@ -295,7 +293,6 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             assertEquals(1, loopStartedCalled.get());
             assertEquals(1, loopFinishedCalled.get());
             assertEquals(1, closeCalled.get());
-            //assertNull(handler.eventLoop());
 
             // Handler has been removed.
             assertEquals(0, eventLoop.handlerCount());
@@ -334,7 +331,6 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             assertEquals(1, loopStartedCalled.get());
             assertEquals(1, loopFinishedCalled.get());
             assertEquals(1, closeCalled.get());
-            //assertNull(handler.eventLoop());
 
             // Handler has been removed.
             assertEquals(0, eventLoop.handlerCount());
@@ -351,7 +347,7 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
         try (MediumEventLoop eventLoop = new MediumEventLoop(null, "name", Pauser.balanced(), true, null)) {
 
             // Add the handler.
-            GoodHandler handler = new GoodHighHandler();
+            GoodHighHandler handler = new GoodHighHandler();
             eventLoop.addHandler(handler);
 
             // Start the loop.
@@ -372,7 +368,6 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             assertEquals(1, loopStartedCalled.get());
             assertEquals(1, loopFinishedCalled.get());
             assertEquals(0, closeCalled.get());
-            //assertNull(handler.eventLoop());
         }
 
         // Check the handler.
@@ -390,7 +385,7 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
 
             // Add the handler.
-            GoodHandler handler = new GoodHandler();
+            GoodHighHandler handler = new GoodHighHandler();
             eventLoop.addHandler(handler);
 
             Waiters.waitForCondition("Loop started called",() -> (loopStartedCalled.get() > 0), 5000);
@@ -409,7 +404,6 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             assertEquals(1, loopStartedCalled.get());
             assertEquals(1, loopFinishedCalled.get());
             assertEquals(0, closeCalled.get());
-            //assertNull(handler.eventLoop());
         }
 
         // Check the handler.
@@ -449,7 +443,6 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             assertEquals(1, loopStartedCalled.get());
             assertEquals(1, loopFinishedCalled.get());
             assertEquals(1, closeCalled.get());
-            //assertNull(handler.eventLoop());
 
             // Handler has been removed.
             assertEquals(0, eventLoop.handlerCount());
@@ -488,7 +481,6 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             assertEquals(1, loopStartedCalled.get());
             assertEquals(1, loopFinishedCalled.get());
             assertEquals(1, closeCalled.get());
-            //assertNull(handler.eventLoop());
 
             // Handler has been removed.
             assertEquals(0, eventLoop.handlerCount());

--- a/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
@@ -20,108 +20,20 @@ package net.openhft.chronicle.threads;
 
 import net.openhft.chronicle.core.io.InvalidMarshallableException;
 import net.openhft.chronicle.core.threads.EventHandler;
-import net.openhft.chronicle.core.threads.EventLoop;
 import net.openhft.chronicle.core.threads.HandlerPriority;
 import net.openhft.chronicle.core.threads.InvalidEventHandlerException;
 import net.openhft.chronicle.testframework.ExecutorServiceUtil;
 import net.openhft.chronicle.testframework.Waiters;
-import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.Closeable;
-import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
+import static net.openhft.chronicle.threads.TestEventHandlers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MediumEventLoopTest extends ThreadsTestCommon {
-
-    private static final String HANDLER_LOOP_STARTED_EXCEPTION_TXT = "Something went wrong in loopStarted!!!";
-    private static final String HANDLER_LOOP_FINISHED_EXCEPTION_TXT = "Something went wrong in loopFinished!!!";
-    private static final String HANDLER_CLOSE_EXCEPTION_TXT = "Something went wrong in close!!!";
-
-    final AtomicInteger loopStartedCalled = new AtomicInteger();
-    final AtomicInteger loopFinishedCalled = new AtomicInteger();
-    final AtomicInteger closeCalled = new AtomicInteger();
-
-    class GoodHandler implements EventHandler, Closeable {
-        private EventLoop eventLoop;
-
-        @Override
-        public void eventLoop(EventLoop eventLoop) {
-            this.eventLoop = eventLoop;
-        }
-
-        public EventLoop eventLoop() {
-            return eventLoop;
-        }
-
-        @Override
-        public void loopStarted() {
-            loopStartedCalled.incrementAndGet();
-        }
-
-        @Override
-        public boolean action() {
-            return false;
-        }
-
-        @Override
-        public void loopFinished() {
-            loopFinishedCalled.incrementAndGet();
-        }
-
-        @Override
-        public void close() throws IOException {
-            closeCalled.incrementAndGet();
-        }
-    }
-
-    class GoodHighHandler extends GoodHandler {
-        @Override
-        public @NotNull HandlerPriority priority() {
-            return HandlerPriority.HIGH;
-        }
-    }
-
-    class ThrowingHandler extends GoodHandler {
-
-        @Override
-        public void loopStarted() {
-            super.loopStarted();
-            throw new IllegalStateException(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
-        }
-
-        @Override
-        public void loopFinished() {
-            super.loopFinished();
-            throw new IllegalStateException(HANDLER_LOOP_FINISHED_EXCEPTION_TXT);
-        }
-
-        @Override
-        public void close() throws IOException {
-            super.close();
-            throw new IllegalStateException(HANDLER_CLOSE_EXCEPTION_TXT);
-        }
-    }
-
-    class ThrowingHighHandler extends ThrowingHandler {
-        @Override
-        public @NotNull HandlerPriority priority() {
-            return HandlerPriority.HIGH;
-        }
-    }
-
-    @BeforeEach
-    public void beforeEach() {
-        loopStartedCalled.set(0);
-        loopFinishedCalled.set(0);
-        closeCalled.set(0);
-    }
 
     @Test
     public void testAddingTwoEventHandlersBeforeStartingLoopIsThreadSafe() {
@@ -180,25 +92,21 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
         }
     }
 
-    // MediumHandler tests
-
-    @Test
-    void addingHandlerBeforeStart() {
+    void addingHandlerBeforeStart(CountingHandler handler) {
         try (MediumEventLoop eventLoop = new MediumEventLoop(null, "name", Pauser.balanced(), true, null)) {
 
             // Add the handler.
-            GoodHandler handler = new GoodHandler();
             eventLoop.addHandler(handler);
 
             // Start the loop.
             eventLoop.start();
             Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
-            Waiters.waitForCondition("loop started called", () -> (loopStartedCalled.get() > 0), 5000);
+            Waiters.waitForCondition("loop started called", () -> (handler.loopStartedCalled() > 0), 5000);
 
             // Check the handler.
-            assertEquals(1, loopStartedCalled.get());
-            assertEquals(0, loopFinishedCalled.get());
-            assertEquals(0, closeCalled.get());
+            assertEquals(1, handler.loopStartedCalled());
+            assertEquals(0, handler.loopFinishedCalled());
+            assertEquals(0, handler.closeCalled());
             assertNotNull(handler.eventLoop());
 
             // Stop the loop.
@@ -206,151 +114,43 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             Waiters.waitForCondition("Event loop stopped", eventLoop::isStopped, 5000);
 
             // Check the handler.
-            assertEquals(1, loopStartedCalled.get());
-            assertEquals(1, loopFinishedCalled.get());
-            assertEquals(0, closeCalled.get());
+            assertEquals(1, handler.loopStartedCalled());
+            assertEquals(1, handler.loopFinishedCalled());
+            assertEquals(0, handler.closeCalled());
         }
 
         // Check the handler.
-        assertEquals(1, loopStartedCalled.get());
-        assertEquals(1, loopFinishedCalled.get());
-        assertEquals(1, closeCalled.get());
+        assertEquals(1, handler.loopStartedCalled());
+        assertEquals(1, handler.loopFinishedCalled());
+        assertEquals(1, handler.closeCalled());
     }
 
     @Test
-    void addingHandlerAfterStart() {
-        try (MediumEventLoop eventLoop = new MediumEventLoop(null, "name", Pauser.balanced(), true, null)) {
-
-            // Start the loop.
-            eventLoop.start();
-            Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
-
-            // Add the handler.
-            GoodHandler handler = new GoodHandler();
-            eventLoop.addHandler(handler);
-
-            Waiters.waitForCondition("Loop started called",() -> (loopStartedCalled.get() > 0), 5000);
-
-            // Check the handler.
-            assertEquals(1, loopStartedCalled.get());
-            assertEquals(0, loopFinishedCalled.get());
-            assertEquals(0, closeCalled.get());
-            assertNotNull(handler.eventLoop());
-
-            // Stop the loop.
-            eventLoop.stop();
-            Waiters.waitForCondition("Event loop stopped", eventLoop::isStopped, 5000);
-
-            // Check the handler.
-            assertEquals(1, loopStartedCalled.get());
-            assertEquals(1, loopFinishedCalled.get());
-            assertEquals(0, closeCalled.get());
-        }
-
-        // Check the handler.
-        assertEquals(1, loopStartedCalled.get());
-        assertEquals(1, loopFinishedCalled.get());
-        assertEquals(1, closeCalled.get());
+    void addingMediumHandlerBeforeStart() {
+        addingHandlerBeforeStart(new CountingHandler(HandlerPriority.MEDIUM));
     }
-
-    @Test
-    void handlerRemovedAddingHandlerBeforeStart() {
-        try (MediumEventLoop eventLoop = new MediumEventLoop(null, "name", Pauser.balanced(), true, null)) {
-            expectException(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
-            expectException(HANDLER_LOOP_FINISHED_EXCEPTION_TXT);
-            expectException(HANDLER_CLOSE_EXCEPTION_TXT);
-
-            // Add handler before loop has started. loopStarted not called yet.
-            ThrowingHandler handler = new ThrowingHandler();
-            eventLoop.addHandler(handler);
-
-            // Start the loop. loopStarted called and exception thrown. Expect handler to be removed.
-            eventLoop.start();
-
-            // Wait for loop to start and handler to be removed.
-            Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
-            Waiters.waitForCondition("Handler should be closed", () -> (closeCalled.get() > 0), 5000);
-            Waiters.waitForCondition("Handler should be removed", () -> (eventLoop.handlerCount() == 0), 5000);
-
-            assertTrue(eventLoop.isAlive());
-            assertTrue(eventLoop.newHandlers.isEmpty());
-
-            // Exceptions should be thrown.
-            assertExceptionThrown(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
-            assertExceptionThrown(HANDLER_LOOP_FINISHED_EXCEPTION_TXT);
-            assertExceptionThrown(HANDLER_CLOSE_EXCEPTION_TXT);
-
-            // Methods called once.
-            assertEquals(1, loopStartedCalled.get());
-            assertEquals(1, loopFinishedCalled.get());
-            assertEquals(1, closeCalled.get());
-
-            // Handler has been removed.
-            assertEquals(0, eventLoop.handlerCount());
-
-            // Event loop is running.
-            checkEventLoopAlive(eventLoop);
-        }
-    }
-
-    @Test
-    void handlerRemovedAddingHandlerDuringEventLoop() {
-        try (MediumEventLoop eventLoop = new MediumEventLoop(null, "name", Pauser.balanced(), true, null)) {
-            expectException(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
-            expectException(HANDLER_LOOP_FINISHED_EXCEPTION_TXT);
-            expectException(HANDLER_CLOSE_EXCEPTION_TXT);
-
-            // start the event loop with no handlers.
-            eventLoop.start();
-
-            // Wait for the handler to be started.
-            Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
-
-            // Add the new handler. It should be picked up by the event loop and removed after exception in loopStarted.
-            ThrowingHandler handler = new ThrowingHandler();
-            eventLoop.addHandler(handler);
-
-            // Wait for handler to be removed.
-            Waiters.waitForCondition("Handler should be closed", () -> (closeCalled.get() > 0), 5000);
-            Waiters.waitForCondition("Handler should be removed", () -> (eventLoop.handlerCount() == 0), 5000);
-
-            // Exceptions should be thrown.
-            assertExceptionThrown(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
-            assertExceptionThrown(HANDLER_LOOP_FINISHED_EXCEPTION_TXT);
-            assertExceptionThrown(HANDLER_CLOSE_EXCEPTION_TXT);
-
-            // Methods called once.
-            assertEquals(1, loopStartedCalled.get());
-            assertEquals(1, loopFinishedCalled.get());
-            assertEquals(1, closeCalled.get());
-
-            // Handler has been removed.
-            assertEquals(0, eventLoop.handlerCount());
-
-            // Event loop is running.
-            checkEventLoopAlive(eventLoop);
-        }
-    }
-
-    // High Handler test cases.
 
     @Test
     void addingHighHandlerBeforeStart() {
-        try (MediumEventLoop eventLoop = new MediumEventLoop(null, "name", Pauser.balanced(), true, null)) {
+        addingHandlerBeforeStart(new CountingHandler(HandlerPriority.HIGH));
+    }
 
-            // Add the handler.
-            GoodHighHandler handler = new GoodHighHandler();
-            eventLoop.addHandler(handler);
+    void addingHandlerAfterStart(CountingHandler handler) {
+        try (MediumEventLoop eventLoop = new MediumEventLoop(null, "name", Pauser.balanced(), true, null)) {
 
             // Start the loop.
             eventLoop.start();
             Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
-            Waiters.waitForCondition("loop started called", () -> (loopStartedCalled.get() > 0), 5000);
+
+            // Add the handler.
+            eventLoop.addHandler(handler);
+
+            Waiters.waitForCondition("Loop started called",() -> (handler.loopStartedCalled() > 0), 5000);
 
             // Check the handler.
-            assertEquals(1, loopStartedCalled.get());
-            assertEquals(0, loopFinishedCalled.get());
-            assertEquals(0, closeCalled.get());
+            assertEquals(1, handler.loopStartedCalled());
+            assertEquals(0, handler.loopFinishedCalled());
+            assertEquals(0, handler.closeCalled());
             assertNotNull(handler.eventLoop());
 
             // Stop the loop.
@@ -358,63 +158,35 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             Waiters.waitForCondition("Event loop stopped", eventLoop::isStopped, 5000);
 
             // Check the handler.
-            assertEquals(1, loopStartedCalled.get());
-            assertEquals(1, loopFinishedCalled.get());
-            assertEquals(0, closeCalled.get());
+            assertEquals(1, handler.loopStartedCalled());
+            assertEquals(1, handler.loopFinishedCalled());
+            assertEquals(0, handler.closeCalled());
         }
 
         // Check the handler.
-        assertEquals(1, loopStartedCalled.get());
-        assertEquals(1, loopFinishedCalled.get());
-        assertEquals(1, closeCalled.get());
+        assertEquals(1, handler.loopStartedCalled());
+        assertEquals(1, handler.loopFinishedCalled());
+        assertEquals(1, handler.closeCalled());
+    }
+
+    @Test
+    void addingMediumHandlerAfterStart() {
+        addingHandlerAfterStart(new CountingHandler(HandlerPriority.MEDIUM));
     }
 
     @Test
     void addingHighHandlerAfterStart() {
-        try (MediumEventLoop eventLoop = new MediumEventLoop(null, "name", Pauser.balanced(), true, null)) {
-
-            // Start the loop.
-            eventLoop.start();
-            Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
-
-            // Add the handler.
-            GoodHighHandler handler = new GoodHighHandler();
-            eventLoop.addHandler(handler);
-
-            Waiters.waitForCondition("Loop started called",() -> (loopStartedCalled.get() > 0), 5000);
-
-            // Check the handler.
-            assertEquals(1, loopStartedCalled.get());
-            assertEquals(0, loopFinishedCalled.get());
-            assertEquals(0, closeCalled.get());
-            assertNotNull(handler.eventLoop());
-
-            // Stop the loop.
-            eventLoop.stop();
-            Waiters.waitForCondition("Event loop stopped", eventLoop::isStopped, 5000);
-
-            // Check the handler.
-            assertEquals(1, loopStartedCalled.get());
-            assertEquals(1, loopFinishedCalled.get());
-            assertEquals(0, closeCalled.get());
-        }
-
-        // Check the handler.
-        assertEquals(1, loopStartedCalled.get());
-        assertEquals(1, loopFinishedCalled.get());
-        assertEquals(1, closeCalled.get());
+        addingHandlerAfterStart(new CountingHandler(HandlerPriority.HIGH));
     }
 
+    void throwingHandlerAddedBeforeStart(ThrowingHandler handler) {
 
-    @Test
-    void highHandlerRemovedAddingHandlerBeforeStart() {
         try (MediumEventLoop eventLoop = new MediumEventLoop(null, "name", Pauser.balanced(), true, null)) {
             expectException(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
             expectException(HANDLER_LOOP_FINISHED_EXCEPTION_TXT);
             expectException(HANDLER_CLOSE_EXCEPTION_TXT);
 
             // Add handler before loop has started. loopStarted not called yet.
-            ThrowingHandler handler = new ThrowingHighHandler();
             eventLoop.addHandler(handler);
 
             // Start the loop. loopStarted called and exception thrown. Expect handler to be removed.
@@ -422,7 +194,7 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
 
             // Wait for loop to start and handler to be removed.
             Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
-            Waiters.waitForCondition("Handler should be closed", () -> (closeCalled.get() > 0), 5000);
+            Waiters.waitForCondition("Handler should be closed", () -> (handler.closeCalled() > 0), 5000);
             Waiters.waitForCondition("Handler should be removed", () -> (eventLoop.handlerCount() == 0), 5000);
 
             assertTrue(eventLoop.isAlive());
@@ -434,10 +206,9 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             assertExceptionThrown(HANDLER_CLOSE_EXCEPTION_TXT);
 
             // Methods called once.
-            assertEquals(1, loopStartedCalled.get());
-            assertEquals(1, loopFinishedCalled.get());
-            assertEquals(1, closeCalled.get());
-
+            assertEquals(1, handler.loopStartedCalled());
+            assertEquals(1, handler.loopFinishedCalled());
+            assertEquals(1, handler.closeCalled());
             // Handler has been removed.
             assertEquals(0, eventLoop.handlerCount());
 
@@ -447,7 +218,16 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
     }
 
     @Test
-    void handlerRemovedUpdatingHighHandlerDuringEventLoop() {
+    void throwingMediumHandlerAddedBeforeStart() {
+        throwingHandlerAddedBeforeStart(new ThrowingHandler(HandlerPriority.MEDIUM, false, false));
+    }
+
+    @Test
+    void throwingHighHandlerAddedBeforeStart() {
+        throwingHandlerAddedBeforeStart(new ThrowingHandler(HandlerPriority.HIGH, false, false));
+    }
+
+    void throwingHandlerAddingAfterStart(ThrowingHandler handler) {
         try (MediumEventLoop eventLoop = new MediumEventLoop(null, "name", Pauser.balanced(), true, null)) {
             expectException(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
             expectException(HANDLER_LOOP_FINISHED_EXCEPTION_TXT);
@@ -460,11 +240,10 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
 
             // Add the new handler. It should be picked up by the event loop and removed after exception in loopStarted.
-            ThrowingHandler handler = new ThrowingHighHandler();
             eventLoop.addHandler(handler);
 
             // Wait for handler to be removed.
-            Waiters.waitForCondition("Handler should be closed", () -> (closeCalled.get() > 0), 5000);
+            Waiters.waitForCondition("Handler should be closed", () -> (handler.closeCalled() > 0), 5000);
             Waiters.waitForCondition("Handler should be removed", () -> (eventLoop.handlerCount() == 0), 5000);
 
             // Exceptions should be thrown.
@@ -473,9 +252,9 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             assertExceptionThrown(HANDLER_CLOSE_EXCEPTION_TXT);
 
             // Methods called once.
-            assertEquals(1, loopStartedCalled.get());
-            assertEquals(1, loopFinishedCalled.get());
-            assertEquals(1, closeCalled.get());
+            assertEquals(1, handler.loopStartedCalled());
+            assertEquals(1, handler.loopFinishedCalled());
+            assertEquals(1, handler.closeCalled());
 
             // Handler has been removed.
             assertEquals(0, eventLoop.handlerCount());
@@ -485,6 +264,15 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
         }
     }
 
+    @Test
+    void testThrowingMediumHandlerAddedAfterStart() {
+        throwingHandlerAddingAfterStart(new ThrowingHandler(HandlerPriority.MEDIUM, false, false));
+    }
+
+    @Test
+    void testThrowingHighHandlerAddedAfterStart() {
+        throwingHandlerAddingAfterStart(new ThrowingHandler(HandlerPriority.HIGH, false, false));
+    }
 
     private void checkEventLoopAlive(MediumEventLoop eventLoop) {
         // Expect the eventLoop to continue.

--- a/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
@@ -193,6 +193,7 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             // Start the loop.
             eventLoop.start();
             Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
+            Waiters.waitForCondition("loop started called", () -> (loopStartedCalled.get() > 0), 5000);
 
             // Check the handler.
             assertEquals(1, loopStartedCalled.get());
@@ -344,6 +345,7 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             // Start the loop.
             eventLoop.start();
             Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
+            Waiters.waitForCondition("loop started called", () -> (loopStartedCalled.get() > 0), 5000);
 
             // Check the handler.
             assertEquals(1, loopStartedCalled.get());

--- a/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
@@ -268,6 +268,7 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
 
             // Wait for loop to start and handler to be removed.
             Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
+            Waiters.waitForCondition("Handler should be closed", () -> (closeCalled.get() > 0), 5000);
             Waiters.waitForCondition("Handler should be removed", () -> (eventLoop.handlerCount() == 0), 5000);
 
             assertTrue(eventLoop.isAlive());
@@ -309,6 +310,7 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             eventLoop.addHandler(handler);
 
             // Wait for handler to be removed.
+            Waiters.waitForCondition("Handler should be closed", () -> (closeCalled.get() > 0), 5000);
             Waiters.waitForCondition("Handler should be removed", () -> (eventLoop.handlerCount() == 0), 5000);
 
             // Exceptions should be thrown.
@@ -418,6 +420,7 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
 
             // Wait for loop to start and handler to be removed.
             Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
+            Waiters.waitForCondition("Handler should be closed", () -> (closeCalled.get() > 0), 5000);
             Waiters.waitForCondition("Handler should be removed", () -> (eventLoop.handlerCount() == 0), 5000);
 
             assertTrue(eventLoop.isAlive());
@@ -459,6 +462,7 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             eventLoop.addHandler(handler);
 
             // Wait for handler to be removed.
+            Waiters.waitForCondition("Handler should be closed", () -> (closeCalled.get() > 0), 5000);
             Waiters.waitForCondition("Handler should be removed", () -> (eventLoop.handlerCount() == 0), 5000);
 
             // Exceptions should be thrown.

--- a/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
@@ -90,17 +90,6 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
 
     class ThrowingHandler extends GoodHandler {
 
-        private EventLoop eventLoop;
-
-        @Override
-        public void eventLoop(EventLoop eventLoop) {
-            this.eventLoop = eventLoop;
-        }
-
-        public EventLoop eventLoop() {
-            return eventLoop;
-        }
-
         @Override
         public void loopStarted() {
             super.loopStarted();
@@ -279,7 +268,7 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
 
             // Wait for loop to start and handler to be removed.
             Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
-            Waiters.waitForCondition("Handler should be removed", () -> (closeCalled.get() > 0), 5000);
+            Waiters.waitForCondition("Handler should be removed", () -> (eventLoop.handlerCount() == 0), 5000);
 
             assertTrue(eventLoop.isAlive());
             assertTrue(eventLoop.newHandlers.isEmpty());
@@ -320,7 +309,7 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             eventLoop.addHandler(handler);
 
             // Wait for handler to be removed.
-            Waiters.waitForCondition("Handler should be removed", () -> (closeCalled.get() > 0), 5000);
+            Waiters.waitForCondition("Handler should be removed", () -> (eventLoop.handlerCount() == 0), 5000);
 
             // Exceptions should be thrown.
             assertExceptionThrown(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
@@ -429,7 +418,7 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
 
             // Wait for loop to start and handler to be removed.
             Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
-            Waiters.waitForCondition("Handler should be removed", () -> (closeCalled.get() > 0), 5000);
+            Waiters.waitForCondition("Handler should be removed", () -> (eventLoop.handlerCount() == 0), 5000);
 
             assertTrue(eventLoop.isAlive());
             assertTrue(eventLoop.newHandlers.isEmpty());
@@ -470,7 +459,7 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
             eventLoop.addHandler(handler);
 
             // Wait for handler to be removed.
-            Waiters.waitForCondition("Handler should be removed", () -> (closeCalled.get() > 0), 5000);
+            Waiters.waitForCondition("Handler should be removed", () -> (eventLoop.handlerCount() == 0), 5000);
 
             // Exceptions should be thrown.
             assertExceptionThrown(HANDLER_LOOP_STARTED_EXCEPTION_TXT);

--- a/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
@@ -33,10 +33,10 @@ import java.util.stream.IntStream;
 import static net.openhft.chronicle.threads.TestEventHandlers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class MediumEventLoopTest extends ThreadsTestCommon {
+class MediumEventLoopTest extends ThreadsTestCommon {
 
     @Test
-    public void testAddingTwoEventHandlersBeforeStartingLoopIsThreadSafe() {
+    void testAddingTwoEventHandlersBeforeStartingLoopIsThreadSafe() {
         for (int i = 0; i < 10_000; i++) {
             try (MediumEventLoop eventLoop = new MediumEventLoop(null, "name", Pauser.balanced(), true, null)) {
                 CyclicBarrier barrier = new CyclicBarrier(2);
@@ -56,7 +56,7 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
     }
 
     @Test
-    public void testAddingTwoEventHandlersWithBlockedMainLoopDoesNotHang() {
+    void testAddingTwoEventHandlersWithBlockedMainLoopDoesNotHang() {
         for (int i = 0; i < 10_000; i++) {
             try (MediumEventLoop eventLoop = new MediumEventLoop(null, "name", Pauser.balanced(), true, null)) {
                 eventLoop.start();

--- a/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
@@ -72,13 +72,11 @@ public class MediumEventLoopTest extends ThreadsTestCommon {
 
         @Override
         public void loopFinished() {
-            Thread.dumpStack();
             loopFinishedCalled.incrementAndGet();
         }
 
         @Override
         public void close() throws IOException {
-            Thread.dumpStack();
             closeCalled.incrementAndGet();
         }
     }

--- a/src/test/java/net/openhft/chronicle/threads/TestEventHandlers.java
+++ b/src/test/java/net/openhft/chronicle/threads/TestEventHandlers.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2016-2024 chronicle.software
+ *
+ *       https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.openhft.chronicle.threads;
 
 import net.openhft.chronicle.core.threads.EventHandler;

--- a/src/test/java/net/openhft/chronicle/threads/TestEventHandlers.java
+++ b/src/test/java/net/openhft/chronicle/threads/TestEventHandlers.java
@@ -1,0 +1,147 @@
+package net.openhft.chronicle.threads;
+
+import net.openhft.chronicle.core.threads.EventHandler;
+import net.openhft.chronicle.core.threads.EventLoop;
+import net.openhft.chronicle.core.threads.HandlerPriority;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestEventHandlers {
+
+    public static class CountingHandler implements EventHandler, Closeable {
+        protected final AtomicInteger loopStartedCalled = new AtomicInteger();
+        protected final AtomicInteger loopFinishedCalled = new AtomicInteger();
+        protected final AtomicInteger actionCalled = new AtomicInteger();
+        protected final AtomicInteger closeCalled = new AtomicInteger();
+        protected final HandlerPriority priority;
+        protected EventLoop eventLoop;
+
+        CountingHandler(HandlerPriority priority) {
+            this.priority = priority;
+        }
+
+        @Override
+        public void eventLoop(EventLoop eventLoop) {
+            this.eventLoop = eventLoop;
+        }
+
+        public EventLoop eventLoop() {
+            return eventLoop;
+        }
+
+        @Override
+        public @NotNull HandlerPriority priority() {
+            return priority;
+        }
+
+        @Override
+        public void loopStarted() {
+            loopStartedCalled.incrementAndGet();
+        }
+
+        public int loopStartedCalled() {
+            return loopStartedCalled.get();
+        }
+
+        @Override
+        public boolean action() {
+            actionCalled.incrementAndGet();
+            return false;
+        }
+
+        public int actionCalled() {
+            return actionCalled.get();
+        }
+
+        @Override
+        public void loopFinished() {
+            loopFinishedCalled.incrementAndGet();
+        }
+
+        public int loopFinishedCalled() {
+            return loopFinishedCalled.get();
+        }
+
+        @Override
+        public void close() throws IOException {
+            closeCalled.incrementAndGet();
+        }
+
+        public int closeCalled() {
+            return closeCalled.get();
+        }
+    }
+
+    public static final String HANDLER_LOOP_STARTED_EXCEPTION_TXT = "Something went wrong in loopStarted!!!";
+    public static final String HANDLER_LOOP_FINISHED_EXCEPTION_TXT = "Something went wrong in loopFinished!!!";
+    public static final String HANDLER_CLOSE_EXCEPTION_TXT = "Something went wrong in close!!!";
+    public static final String HANDLER_EVENT_LOOP_EXCEPTION_TXT = "Something went wrong in set eventLoop!!!";
+    public static final String HANDLER_PRIORITY_EXCEPTION_TXT = "Something went wrong in priority!!!";
+
+    public static class ThrowingHandler extends CountingHandler {
+        protected final boolean throwsEventLoop;
+        protected final boolean throwsPriority;
+        protected final boolean throwsLoopStarted;
+        protected final boolean throwsLoopFinished;
+        protected final boolean throwsClose;
+
+        ThrowingHandler(HandlerPriority priority, boolean throwsEventLoop, boolean throwsPriority) {
+            super(priority);
+            this.throwsEventLoop = throwsEventLoop;
+            this.throwsPriority = throwsPriority;
+            if (throwsEventLoop || throwsPriority) {
+                throwsLoopStarted = false;
+                throwsLoopFinished = false;
+                throwsClose = false;
+            } else {
+                throwsLoopStarted = true;
+                throwsLoopFinished = true;
+                throwsClose = true;
+            }
+        }
+
+        @Override
+        public void eventLoop(EventLoop eventLoop) {
+            super.eventLoop(eventLoop);
+            if (throwsEventLoop) {
+                throw new IllegalStateException(HANDLER_EVENT_LOOP_EXCEPTION_TXT + priority);
+            }
+        }
+
+        @Override
+        public void loopStarted() {
+            super.loopStarted();
+            if (throwsLoopStarted) {
+                throw new IllegalStateException(HANDLER_LOOP_STARTED_EXCEPTION_TXT + priority);
+            }
+        }
+
+        @Override
+        public void loopFinished() {
+            super.loopFinished();
+            if (throwsLoopFinished) {
+                throw new IllegalStateException(HANDLER_LOOP_FINISHED_EXCEPTION_TXT + priority);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            if (throwsClose) {
+                throw new IllegalStateException(HANDLER_CLOSE_EXCEPTION_TXT + priority);
+            }
+        }
+
+        @Override
+        public @NotNull HandlerPriority priority() {
+            HandlerPriority result = super.priority();
+            if (throwsPriority) {
+                throw new IllegalStateException(HANDLER_PRIORITY_EXCEPTION_TXT + priority);
+            }
+            return result;
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/threads/VanillaEventLoopTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/VanillaEventLoopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2024 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/threads/VanillaEventLoopTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/VanillaEventLoopTest.java
@@ -33,10 +33,10 @@ import java.util.stream.IntStream;
 import static net.openhft.chronicle.threads.TestEventHandlers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class VanillaEventLoopTest extends ThreadsTestCommon {
+class VanillaEventLoopTest extends ThreadsTestCommon {
 
     @Test
-    public void testAddingTwoEventHandlersBeforeStartingLoopIsThreadSafe() {
+    void testAddingTwoEventHandlersBeforeStartingLoopIsThreadSafe() {
         for (int i = 0; i < 10_000; i++) {
             try (VanillaEventLoop eventLoop = new VanillaEventLoop(null, "name", Pauser.balanced(), 1000L, true,"", VanillaEventLoop.ALLOWED_PRIORITIES)) {
                 CyclicBarrier barrier = new CyclicBarrier(2);
@@ -56,7 +56,7 @@ public class VanillaEventLoopTest extends ThreadsTestCommon {
     }
 
     @Test
-    public void testAddingTwoEventHandlersWithBlockedMainLoopDoesNotHang() {
+    void testAddingTwoEventHandlersWithBlockedMainLoopDoesNotHang() {
         for (int i = 0; i < 10_000; i++) {
             try (VanillaEventLoop eventLoop = new VanillaEventLoop(null, "name", Pauser.balanced(), 1000L, true, null, VanillaEventLoop.ALLOWED_PRIORITIES)) {
                 eventLoop.start();

--- a/src/test/java/net/openhft/chronicle/threads/VanillaEventLoopTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/VanillaEventLoopTest.java
@@ -1,0 +1,529 @@
+/*
+ * Copyright 2016-2022 chronicle.software
+ *
+ *       https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openhft.chronicle.threads;
+
+import net.openhft.chronicle.core.io.InvalidMarshallableException;
+import net.openhft.chronicle.core.threads.EventHandler;
+import net.openhft.chronicle.core.threads.EventLoop;
+import net.openhft.chronicle.core.threads.HandlerPriority;
+import net.openhft.chronicle.core.threads.InvalidEventHandlerException;
+import net.openhft.chronicle.testframework.ExecutorServiceUtil;
+import net.openhft.chronicle.testframework.Waiters;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VanillaEventLoopTest extends ThreadsTestCommon {
+
+    private static final String HANDLER_LOOP_STARTED_EXCEPTION_TXT = "Something went wrong in loopStarted!!!";
+    private static final String HANDLER_LOOP_FINISHED_EXCEPTION_TXT = "Something went wrong in loopFinished!!!";
+    private static final String HANDLER_CLOSE_EXCEPTION_TXT = "Something went wrong in close!!!";
+
+    final AtomicInteger loopStartedCalled = new AtomicInteger();
+    final AtomicInteger loopFinishedCalled = new AtomicInteger();
+    final AtomicInteger closeCalled = new AtomicInteger();
+
+    class GoodTimerHandler implements EventHandler, Closeable {
+        private EventLoop eventLoop;
+
+        @Override
+        public void eventLoop(EventLoop eventLoop) {
+            this.eventLoop = eventLoop;
+        }
+
+        public EventLoop eventLoop() {
+            return eventLoop;
+        }
+
+        @Override
+        public @NotNull HandlerPriority priority() {
+            return HandlerPriority.TIMER;
+        }
+
+        @Override
+        public void loopStarted() {
+            loopStartedCalled.incrementAndGet();
+        }
+
+        @Override
+        public boolean action() {
+            return false;
+        }
+
+        @Override
+        public void loopFinished() {
+            loopFinishedCalled.incrementAndGet();
+        }
+
+        @Override
+        public void close() throws IOException {
+            closeCalled.incrementAndGet();
+        }
+    }
+
+    class GoodDaemonHandler extends GoodTimerHandler {
+        @Override
+        public @NotNull HandlerPriority priority() {
+            return HandlerPriority.DAEMON;
+        }
+    }
+
+    class ThrowingTimerHandler extends GoodTimerHandler {
+
+        @Override
+        public void loopStarted() {
+            super.loopStarted();
+            throw new IllegalStateException(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
+        }
+
+        @Override
+        public void loopFinished() {
+            super.loopFinished();
+            throw new IllegalStateException(HANDLER_LOOP_FINISHED_EXCEPTION_TXT);
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            throw new IllegalStateException(HANDLER_CLOSE_EXCEPTION_TXT);
+        }
+    }
+
+    class ThrowingDaemonHandler extends ThrowingTimerHandler {
+        @Override
+        public @NotNull HandlerPriority priority() {
+            return HandlerPriority.DAEMON;
+        }
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        loopStartedCalled.set(0);
+        loopFinishedCalled.set(0);
+        closeCalled.set(0);
+    }
+
+    @Test
+    public void testAddingTwoEventHandlersBeforeStartingLoopIsThreadSafe() {
+        for (int i = 0; i < 10_000; i++) {
+            try (VanillaEventLoop eventLoop = new VanillaEventLoop(null, "name", Pauser.balanced(), 1000L, true,"", VanillaEventLoop.ALLOWED_PRIORITIES)) {
+                CyclicBarrier barrier = new CyclicBarrier(2);
+                IntStream.range(0, 2).parallel()
+                        .forEach(ignored -> {
+                            try {
+                                EventHandler handler = new NoOpHandler();
+                                barrier.await();
+                                eventLoop.addHandler(handler);
+                            } catch (InterruptedException | BrokenBarrierException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+                assertEquals(2, eventLoop.mediumHandlersArray.length);
+            }
+        }
+    }
+
+    @Test
+    public void testAddingTwoEventHandlersWithBlockedMainLoopDoesNotHang() {
+        for (int i = 0; i < 10_000; i++) {
+            try (VanillaEventLoop eventLoop = new VanillaEventLoop(null, "name", Pauser.balanced(), 1000L, true, null, VanillaEventLoop.ALLOWED_PRIORITIES)) {
+                eventLoop.start();
+                CyclicBarrier barrier = new CyclicBarrier(3);
+                eventLoop.addHandler(new EventHandler() {
+                    @Override
+                    public boolean action() throws InvalidEventHandlerException, InvalidMarshallableException {
+                        try {
+                            barrier.await();
+                            return false;
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new InvalidEventHandlerException();
+                        } catch (BrokenBarrierException e) {
+                            throw new InvalidEventHandlerException();
+                        }
+                    }
+                });
+                IntStream.range(0, 2).parallel()
+                        .forEach(ignored -> {
+                            try {
+                                EventHandler handler = new NoOpHandler();
+                                eventLoop.addHandler(handler);
+                                barrier.await();
+                            } catch (InterruptedException | BrokenBarrierException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+
+                Waiters.waitForCondition("Not all handlers arrived in the loop",
+                        () -> eventLoop.mediumHandlersArray.length == 3, 1000);
+            }
+        }
+    }
+
+    // MediumHandler tests
+
+    @Test
+    void addingHandlerBeforeStart() {
+        try (VanillaEventLoop eventLoop = new VanillaEventLoop(null, "name", Pauser.balanced(), 1000L, true, null,VanillaEventLoop.ALLOWED_PRIORITIES)) {
+
+            // Add the handler.
+            GoodTimerHandler handler = new GoodTimerHandler();
+            eventLoop.addHandler(handler);
+
+            // Start the loop.
+            eventLoop.start();
+            Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
+            Waiters.waitForCondition("loop started called", () -> (loopStartedCalled.get() > 0), 5000);
+
+            // Check the handler.
+            assertEquals(1, loopStartedCalled.get());
+            assertEquals(0, loopFinishedCalled.get());
+            assertEquals(0, closeCalled.get());
+            assertNotNull(handler.eventLoop());
+
+            // Stop the loop.
+            eventLoop.stop();
+            Waiters.waitForCondition("Event loop stopped", eventLoop::isStopped, 5000);
+
+            // Check the handler.
+            assertEquals(1, loopStartedCalled.get());
+            assertEquals(1, loopFinishedCalled.get());
+            assertEquals(0, closeCalled.get());
+        }
+
+        // Check the handler.
+        assertEquals(1, loopStartedCalled.get());
+        assertEquals(1, loopFinishedCalled.get());
+        assertEquals(1, closeCalled.get());
+    }
+
+    @Test
+    void addingHandlerAfterStart() {
+        try (VanillaEventLoop eventLoop = new VanillaEventLoop(null, "name", Pauser.balanced(), 1000L, true, null,VanillaEventLoop.ALLOWED_PRIORITIES)) {
+
+            // Start the loop.
+            eventLoop.start();
+            Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
+
+            // Add the handler.
+            GoodTimerHandler handler = new GoodTimerHandler();
+            eventLoop.addHandler(handler);
+
+            Waiters.waitForCondition("Loop started called",() -> (loopStartedCalled.get() > 0), 5000);
+
+            // Check the handler.
+            assertEquals(1, loopStartedCalled.get());
+            assertEquals(0, loopFinishedCalled.get());
+            assertEquals(0, closeCalled.get());
+            assertNotNull(handler.eventLoop());
+
+            // Stop the loop.
+            eventLoop.stop();
+            Waiters.waitForCondition("Event loop stopped", eventLoop::isStopped, 5000);
+
+            // Check the handler.
+            assertEquals(1, loopStartedCalled.get());
+            assertEquals(1, loopFinishedCalled.get());
+            assertEquals(0, closeCalled.get());
+        }
+
+        // Check the handler.
+        assertEquals(1, loopStartedCalled.get());
+        assertEquals(1, loopFinishedCalled.get());
+        assertEquals(1, closeCalled.get());
+    }
+
+    @Test
+    void handlerRemovedAddingHandlerBeforeStart() {
+        try (VanillaEventLoop eventLoop = new VanillaEventLoop(null, "name", Pauser.balanced(), 1000L, true, null,VanillaEventLoop.ALLOWED_PRIORITIES)) {
+            expectException(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
+            expectException(HANDLER_LOOP_FINISHED_EXCEPTION_TXT);
+            expectException(HANDLER_CLOSE_EXCEPTION_TXT);
+
+            // Add handler before loop has started. loopStarted not called yet.
+            ThrowingTimerHandler handler = new ThrowingTimerHandler();
+            eventLoop.addHandler(handler);
+
+            // Start the loop. loopStarted called and exception thrown. Expect handler to be removed.
+            eventLoop.start();
+
+            // Wait for loop to start and handler to be removed.
+            Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
+            Waiters.waitForCondition("Handler should be closed", () -> (closeCalled.get() > 0), 5000);
+            Waiters.waitForCondition("Handler should be removed", () -> (eventLoop.handlerCount() == 0), 5000);
+
+            assertTrue(eventLoop.isAlive());
+            assertTrue(eventLoop.newHandlers.isEmpty());
+
+            // Exceptions should be thrown.
+            assertExceptionThrown(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
+            assertExceptionThrown(HANDLER_LOOP_FINISHED_EXCEPTION_TXT);
+            assertExceptionThrown(HANDLER_CLOSE_EXCEPTION_TXT);
+
+            // Methods called once.
+            assertEquals(1, loopStartedCalled.get());
+            assertEquals(1, loopFinishedCalled.get());
+            assertEquals(1, closeCalled.get());
+
+            // Handler has been removed.
+            assertEquals(0, eventLoop.handlerCount());
+
+            // Event loop is running.
+            checkEventLoopAlive(eventLoop);
+        }
+    }
+
+    @Test
+    void handlerRemovedAddingHandlerDuringEventLoop() {
+        try (VanillaEventLoop eventLoop = new VanillaEventLoop(null, "name", Pauser.balanced(), 1000L, true, null,VanillaEventLoop.ALLOWED_PRIORITIES)) {
+
+            expectException(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
+            expectException(HANDLER_LOOP_FINISHED_EXCEPTION_TXT);
+            expectException(HANDLER_CLOSE_EXCEPTION_TXT);
+
+            // start the event loop with no handlers.
+            eventLoop.start();
+
+            // Wait for the handler to be started.
+            Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
+
+            // Add the new handler. It should be picked up by the event loop and removed after exception in loopStarted.
+            ThrowingTimerHandler handler = new ThrowingTimerHandler();
+            eventLoop.addHandler(handler);
+
+            // Wait for handler to be removed.
+            Waiters.waitForCondition("Handler should be closed", () -> (closeCalled.get() > 0), 5000);
+            Waiters.waitForCondition("Handler should be removed", () -> (eventLoop.handlerCount() == 0), 5000);
+
+            // Exceptions should be thrown.
+            assertExceptionThrown(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
+            assertExceptionThrown(HANDLER_LOOP_FINISHED_EXCEPTION_TXT);
+            assertExceptionThrown(HANDLER_CLOSE_EXCEPTION_TXT);
+
+            // Methods called once.
+            assertEquals(1, loopStartedCalled.get());
+            assertEquals(1, loopFinishedCalled.get());
+            assertEquals(1, closeCalled.get());
+
+            // Handler has been removed.
+            assertEquals(0, eventLoop.handlerCount());
+
+            // Event loop is running.
+            checkEventLoopAlive(eventLoop);
+        }
+    }
+
+    // Daemon Handler test cases.
+
+    @Test
+    void addingHighHandlerBeforeStart() {
+        try (VanillaEventLoop eventLoop = new VanillaEventLoop(null, "name", Pauser.balanced(), 1000L, true, null,VanillaEventLoop.ALLOWED_PRIORITIES)) {
+
+            // Add the handler.
+            GoodDaemonHandler handler = new GoodDaemonHandler();
+            eventLoop.addHandler(handler);
+
+            // Start the loop.
+            eventLoop.start();
+            Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
+            Waiters.waitForCondition("loop started called", () -> (loopStartedCalled.get() > 0), 5000);
+
+            // Check the handler.
+            assertEquals(1, loopStartedCalled.get());
+            assertEquals(0, loopFinishedCalled.get());
+            assertEquals(0, closeCalled.get());
+            assertNotNull(handler.eventLoop());
+
+            // Stop the loop.
+            eventLoop.stop();
+            Waiters.waitForCondition("Event loop stopped", eventLoop::isStopped, 5000);
+
+            // Check the handler.
+            assertEquals(1, loopStartedCalled.get());
+            assertEquals(1, loopFinishedCalled.get());
+            assertEquals(0, closeCalled.get());
+        }
+
+        // Check the handler.
+        assertEquals(1, loopStartedCalled.get());
+        assertEquals(1, loopFinishedCalled.get());
+        assertEquals(1, closeCalled.get());
+    }
+
+    @Test
+    void addingHighHandlerAfterStart() {
+        try (VanillaEventLoop eventLoop = new VanillaEventLoop(null, "name", Pauser.balanced(), 1000L, true, null,VanillaEventLoop.ALLOWED_PRIORITIES)) {
+
+
+            // Start the loop.
+            eventLoop.start();
+            Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
+
+            // Add the handler.
+            GoodDaemonHandler handler = new GoodDaemonHandler();
+            eventLoop.addHandler(handler);
+
+            Waiters.waitForCondition("Loop started called",() -> (loopStartedCalled.get() > 0), 5000);
+
+            // Check the handler.
+            assertEquals(1, loopStartedCalled.get());
+            assertEquals(0, loopFinishedCalled.get());
+            assertEquals(0, closeCalled.get());
+            assertNotNull(handler.eventLoop());
+
+            // Stop the loop.
+            eventLoop.stop();
+            Waiters.waitForCondition("Event loop stopped", eventLoop::isStopped, 5000);
+
+            // Check the handler.
+            assertEquals(1, loopStartedCalled.get());
+            assertEquals(1, loopFinishedCalled.get());
+            assertEquals(0, closeCalled.get());
+        }
+
+        // Check the handler.
+        assertEquals(1, loopStartedCalled.get());
+        assertEquals(1, loopFinishedCalled.get());
+        assertEquals(1, closeCalled.get());
+    }
+
+
+    @Test
+    void highHandlerRemovedAddingHandlerBeforeStart() {
+        try (VanillaEventLoop eventLoop = new VanillaEventLoop(null, "name", Pauser.balanced(), 1000L, true, null,VanillaEventLoop.ALLOWED_PRIORITIES)) {
+
+            expectException(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
+            expectException(HANDLER_LOOP_FINISHED_EXCEPTION_TXT);
+            expectException(HANDLER_CLOSE_EXCEPTION_TXT);
+
+            // Add handler before loop has started. loopStarted not called yet.
+            ThrowingDaemonHandler handler = new ThrowingDaemonHandler();
+            eventLoop.addHandler(handler);
+
+            // Start the loop. loopStarted called and exception thrown. Expect handler to be removed.
+            eventLoop.start();
+
+            // Wait for loop to start and handler to be removed.
+            Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
+            Waiters.waitForCondition("Handler should be closed", () -> (closeCalled.get() > 0), 5000);
+            Waiters.waitForCondition("Handler should be removed", () -> (eventLoop.handlerCount() == 0), 5000);
+
+            assertTrue(eventLoop.isAlive());
+            assertTrue(eventLoop.newHandlers.isEmpty());
+
+            // Exceptions should be thrown.
+            assertExceptionThrown(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
+            assertExceptionThrown(HANDLER_LOOP_FINISHED_EXCEPTION_TXT);
+            assertExceptionThrown(HANDLER_CLOSE_EXCEPTION_TXT);
+
+            // Methods called once.
+            assertEquals(1, loopStartedCalled.get());
+            assertEquals(1, loopFinishedCalled.get());
+            assertEquals(1, closeCalled.get());
+
+            // Handler has been removed.
+            assertEquals(0, eventLoop.handlerCount());
+
+            // Event loop is running.
+            checkEventLoopAlive(eventLoop);
+        }
+    }
+
+    @Test
+    void handlerRemovedUpdatingHighHandlerDuringEventLoop() {
+        try (VanillaEventLoop eventLoop = new VanillaEventLoop(null, "name", Pauser.balanced(), 1000L, true, null,VanillaEventLoop.ALLOWED_PRIORITIES)) {
+
+            expectException(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
+            expectException(HANDLER_LOOP_FINISHED_EXCEPTION_TXT);
+            expectException(HANDLER_CLOSE_EXCEPTION_TXT);
+
+            // start the event loop with no handlers.
+            eventLoop.start();
+
+            // Wait for the handler to be started.
+            Waiters.waitForCondition("Event loop started", eventLoop::isStarted, 5000);
+
+            // Add the new handler. It should be picked up by the event loop and removed after exception in loopStarted.
+            ThrowingDaemonHandler handler = new ThrowingDaemonHandler();
+            eventLoop.addHandler(handler);
+
+            // Wait for handler to be removed.
+            Waiters.waitForCondition("Handler should be closed", () -> (closeCalled.get() > 0), 5000);
+            Waiters.waitForCondition("Handler should be removed", () -> (eventLoop.handlerCount() == 0), 5000);
+
+            // Exceptions should be thrown.
+            assertExceptionThrown(HANDLER_LOOP_STARTED_EXCEPTION_TXT);
+            assertExceptionThrown(HANDLER_LOOP_FINISHED_EXCEPTION_TXT);
+            assertExceptionThrown(HANDLER_CLOSE_EXCEPTION_TXT);
+
+            // Methods called once.
+            assertEquals(1, loopStartedCalled.get());
+            assertEquals(1, loopFinishedCalled.get());
+            assertEquals(1, closeCalled.get());
+
+            // Handler has been removed.
+            assertEquals(0, eventLoop.handlerCount());
+
+            // Event loop is running.
+            checkEventLoopAlive(eventLoop);
+        }
+    }
+
+
+    private void checkEventLoopAlive(VanillaEventLoop eventLoop) {
+        // Expect the eventLoop to continue.
+        assertTrue(eventLoop.isStarted());
+        assertTrue(eventLoop.isAlive());
+        assertFalse(eventLoop.isStopped());
+        assertFalse(eventLoop.isClosing());
+        assertFalse(eventLoop.isClosed());
+        assertTrue(Objects.requireNonNull(eventLoop.thread()).isAlive());
+    }
+
+    @Test
+    void concurrentStartStopDoesNoThrowError() throws ExecutionException, InterruptedException {
+        ExecutorService es = Executors.newCachedThreadPool();
+        for (int i = 0; i < 100; i++) {
+            try (VanillaEventLoop vanillaEventLoop = new VanillaEventLoop(null, "name", Pauser.balanced(), 1000L, true, null,VanillaEventLoop.ALLOWED_PRIORITIES)) {
+                final Future<?> starter = es.submit(vanillaEventLoop::start);
+                final Future<?> stopper = es.submit(vanillaEventLoop::stop);
+                starter.get();
+                stopper.get();
+            }
+        }
+        ExecutorServiceUtil.shutdownAndWaitForTermination(es);
+    }
+
+    private static class NoOpHandler implements EventHandler {
+
+        @Override
+        public boolean action() {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Expected behaviour...
* loopStarted/loopFinished not called if eventLoop not started.
* on event loop start, loopStarted called for each handler, if exception thrown, handler removed and loopFinished called.
* while loop running if handler is added, loopStarted is called and if exception thrown, handler removed and loopFinished called.
* calling loopFinished any exception failure should be logged as warning.
* handler behaviour should not cause eventLoop to terminate.

The action handler should not remove handler on exception.
The action handler should remove handler on InvalidEventHandlerException.