### PR TITLE
deprecate EventGroup constructor - will be made package-private for exclusive use by EventGroupBuilder

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/EventGroup.java
+++ b/src/main/java/net/openhft/chronicle/threads/EventGroup.java
@@ -76,6 +76,7 @@ public class EventGroup
     private final Pauser replicationPauser;
     private VanillaEventLoop replication;
 
+    @Deprecated(/* Instead use EventGroupBuilder. TODO: make package-private and undeprecate in x.28, as only EventGroupBuilder should be using */)
     @SuppressWarnings({"this-escape", "deprecation"})
     public EventGroup(final boolean daemon,
                       @NotNull final Pauser pauser,

--- a/src/main/java/net/openhft/chronicle/threads/EventGroupBuilder.java
+++ b/src/main/java/net/openhft/chronicle/threads/EventGroupBuilder.java
@@ -18,7 +18,6 @@
 
 package net.openhft.chronicle.threads;
 
-import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.threads.EventLoop;
 import net.openhft.chronicle.core.threads.HandlerPriority;
 import net.openhft.chronicle.core.util.Builder;
@@ -59,6 +58,7 @@ public class EventGroupBuilder implements Builder<EventLoop> {
     private EventGroupBuilder() {
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public EventGroup build() {
         return new EventGroup(daemon,


### PR DESCRIPTION
This constructor is still in use by customers, and it would be preferable if they were nudged towards the `EventGroupBuilder`

See [build-all](https://teamcity.chronicle.software/project/Chronicle_BuildAll?branch=deprecate_eg_ctor&mode=builds#all-projects)