### PR TITLE
Clarify CoreEventLoop methods in Javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/CoreEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/CoreEventLoop.java
@@ -22,6 +22,13 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.function.BooleanSupplier;
 
+/**
+ * Contract for the fast core loop used within an {@link EventGroup}.
+ *
+ * <p>The core loop runs on a dedicated thread and executes handlers
+ * one by one. Implementations aim to minimise latency and usually rely
+ * on a {@link net.openhft.chronicle.threads.Pauser} during idle periods.
+ */
 public interface CoreEventLoop extends EventLoop {
 
     /**
@@ -31,18 +38,36 @@ public interface CoreEventLoop extends EventLoop {
     long NOT_IN_A_LOOP = Long.MAX_VALUE;
 
     /**
-     * @return thread that the event loop is running on. Will be null if the event loop has not started
+     * The thread currently running the loop.
+     *
+     * @return the loop thread, or {@code null} if the loop has not yet started
+     * or has finished
      */
     Thread thread();
 
     /**
-     * Get the {@link System#nanoTime()} at which the currently executing loop iteration started
+     * Time in {@link System#nanoTime()} units when the current iteration began.
      *
-     * @return The time the current loop started, or {@link #NOT_IN_A_LOOP} if no iteration is executing
+     * @return the start time, or {@link #NOT_IN_A_LOOP} if the loop is idle
      */
     long loopStartNS();
 
-    void dumpRunningState(@NotNull final String message, @NotNull final BooleanSupplier finalCheck);
+    /**
+     * Dump the stack trace when a monitor suspects the loop is blocked.
+     *
+     * @param message    text to include in the log
+     * @param finalCheck invoked after taking the stack trace; the state is
+     *                   logged only when this returns {@code true}
+     */
+    void dumpRunningState(@NotNull String message, @NotNull BooleanSupplier finalCheck);
 
+    /**
+     * Check whether the given thread is executing this loop.
+     *
+     * <p>Used by diagnostics to ignore activity from other threads.</p>
+     *
+     * @param thread candidate thread
+     * @return {@code true} if the loop is running on {@code thread}
+     */
     boolean isRunningOnThread(Thread thread);
 }


### PR DESCRIPTION
## Summary
- document what a core event loop is used for
- clarify thread() behaviour and loopStartNS semantics
- explain dumpRunningState() parameters
- note typical use of isRunningOnThread()

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*