### PR TITLE
Refine system property documentation

### DIFF
--- a/systemProperties.adoc
+++ b/systemProperties.adoc
@@ -1,27 +1,44 @@
 == System Properties
-Below, a number of relevant System Properties are listed.
+Chronicle Threads reads several system properties at start up. These values tune
+event loops, pausing strategies, monitoring intervals and disk space checks. All
+properties may be supplied on the command line with `-D` flags.
 
+NOTE: All boolean properties below are read using link:https://javadoc.io/static/net.openhft/chronicle-core/2.23ea13/net/openhft/chronicle/core/Jvm.html#getBoolean-java.lang.String-[net.openhft.chronicle.core.Jvm.getBoolean(java.lang.String)], and so are enabled if either `-Dflag` or `-Dflag=true` or `-Dflag=yes`.
 
-
-NOTE: All boolean properties below are read using link:https://javadoc.io/static/net.openhft/chronicle-core/2.23ea13/net/openhft/chronicle/core/Jvm.html#getBoolean-java.lang.String-[net.openhft.chronicle.core.Jvm.getBoolean(java.lang.String)], and so are enabled if either `-Dflag` or `-Dflag=true` or `-Dflag=yes`
-
-
-.System properties
+=== Disk monitoring
 [cols=4*, options="header"]
 |===
 | Property Key | Default | Description | Java Variable Name (Type)
-| chronicle.disk.monitor.disable | `false` | See NOTE above to enable this feature | _DISABLED_ (boolean)
-| chronicle.disk.monitor.threshold.percent | 0 | Gets diskSpaceFull % and warns that chronicle-queue may crash if there is not enough disk space | _thresholdPercentage_ (int)
-| disableLoopBlockMonitor | `false` | If enabled, triggers addThreadMonitoring | _ENABLE_LOOP_BLOCK_MONITOR_ (boolean)
-| disk.monitor.deleted.warning | `false` | If enabled, displays 'unable to get disk space' warning message | _WARN_DELETED_ (boolean)
-| eventloop.accept.mod | 128 | This is used for preventing starvation for new event handlers, each modulo, potentially new event handlers are added even though there might be other handlers that are busy | _ACCEPT_HANDLER_MOD_COUNT_ (int)
-| eventGroup.conc.threads | unknown | Returns the number of concurrent threads | _CONC_THREADS_ (int)
-| eventGroup.wait.to.start.ms | 1_000 | Sets waiting time for core to start | _WAIT_TO_START_MS_ (long)
-| ignoreThreadMonitorEventHandler | `false` | If enabled, throws new InvalidEventHandlerException and warning message | _IGNORE_THREAD_MONITOR_EVENT_HANDLER_ (boolean)
-| MONITOR_INTERVAL_MS | 100L | This checks that the core threads have stalled | _MONITOR_INTERVAL_MS_ (long)
-| pauser.minProcessors | 6 | Minimum required number of processors | _MIN_PROCESSORS_ (int)
-| replicationEventPauseTime | 20 SECS | Pause between replication events | _REPLICATION_EVENT_PAUSE_TIME_ (int)
-| REPLICATION_MONITOR_INTERVAL_MS | 500L | Sets interval of monitoring bind replication | _REPLICATION_MONITOR_INTERVAL_MS_ (long)
-| SHUTDOWN_WAIT_MS | 500L | Triggered after service's tasks have already been told to stop, and this stops the service | _SHUTDOWN_WAIT_MILLIS_ (long)
-| threads.timing.error | 20_000_000 | Set threads timing error | _TIMING_ERROR_ (int)
+| chronicle.disk.monitor.disable | `false` | Disable the background disk space monitor | _DISABLED_ (boolean)
+| chronicle.disk.monitor.threshold.percent | 5% | Issue warnings when free space drops below this percentage | _thresholdPercentage_ (int)
+| disk.monitor.deleted.warning | `false` | Warn if disk space cannot be determined | _WARN_DELETED_ (boolean)
+|===
+
+=== Event loops
+[cols=4*, options="header"]
+|===
+| Property Key | Default | Description | Java Variable Name (Type)
+| eventloop.accept.mod | 128 | Prevent starvation by inserting new handlers every modulo iteration | _ACCEPT_HANDLER_MOD_COUNT_ (int)
+| eventGroup.conc.threads | processors/4 | Number of concurrent event loop threads (minimum one) | _CONC_THREADS_ (int)
+| eventGroup.wait.to.start.ms | 2_000 ms | Delay before the core event loop begins | _WAIT_TO_START_MS_ (long)
+| replicationEventPauseTime | 20 ms | Pause time used for replication event pausers | _REPLICATION_EVENT_PAUSE_TIME_ (int)
+| REPLICATION_MONITOR_INTERVAL_MS | 500 ms | Interval for monitoring replication loops | _REPLICATION_MONITOR_INTERVAL_MS_ (long)
+|===
+
+=== Pausers
+[cols=4*, options="header"]
+|===
+| Property Key | Default | Description | Java Variable Name (Type)
+| pauser.minProcessors | 4 | Minimum number of processors required before busy pausing is used | _MIN_PROCESSORS_ (int)
+|===
+
+=== Monitoring
+[cols=4*, options="header"]
+|===
+| Property Key | Default | Description | Java Variable Name (Type)
+| disableLoopBlockMonitor | `false` | Disable loop block monitoring | _ENABLE_LOOP_BLOCK_MONITOR_ (boolean)
+| ignoreThreadMonitorEventHandler | `false` | If enabled, throw an exception when thread monitoring fails | _IGNORE_THREAD_MONITOR_EVENT_HANDLER_ (boolean)
+| MONITOR_INTERVAL_MS | 100 ms | Sampling interval for monitoring core threads | _MONITOR_INTERVAL_MS_ (long)
+| SHUTDOWN_WAIT_MS | 500 ms | Time to wait for services to stop on shutdown | _SHUTDOWN_WAIT_MILLIS_ (long)
+| threads.timing.error | 80_000_000 ns | Allowed timing error for loop execution | _TIMING_ERROR_ (int)
 |===


### PR DESCRIPTION
## Summary
- document how Chronicle Threads uses system properties
- group properties by area
- fix default values and add units

## Testing
- `mvn -q verify` *(fails: command not found)*