### PR TITLE
Clarify busy pauser docs

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/BusyPauser.java
+++ b/src/main/java/net/openhft/chronicle/threads/BusyPauser.java
@@ -23,10 +23,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * Implementation of {@link Pauser} that employs a busy-wait strategy to keep the CPU actively engaged.
- * This pauser continuously executes a very short pause (nano-pause) to keep the thread active.
- *
- * <p>Because it never actually suspends the thread, most operations related to state management (like pausing, unpausing, and timeout handling) are unsupported or no-op.</p>
+ * Busy-spin implementation of {@link Pauser}.
+ * <p>
+ * The pauser repeatedly invokes {@link Jvm#nanoPause()} and never yields or
+ * sleeps. A thread using this pauser therefore consumes an entire CPU core
+ * while waiting. No state is kept, so most lifecycle methods are no-ops.
  */
 public enum BusyPauser implements Pauser {
     INSTANCE;
@@ -40,8 +41,8 @@ public enum BusyPauser implements Pauser {
     }
 
     /**
-     * Keeps the thread actively busy by executing a very short pause at the CPU level.
-     * This method is primarily used to prevent the thread from yielding execution entirely.
+     * Performs a single busy-spin step by calling {@link Jvm#nanoPause()}.
+     * The call neither yields nor sleeps and therefore burns CPU cycles.
      */
     @Override
     public void pause() {
@@ -49,10 +50,11 @@ public enum BusyPauser implements Pauser {
     }
 
     /**
-     * Throws {@link UnsupportedOperationException} as {@code BusyPauser} does not support pausing with a timeout.
+     * Unsupported operation as this pauser is stateless.
+     * Use {@link BusyTimedPauser} when a timeout is required.
      *
-     * @param timeout  the timeout duration
-     * @param timeUnit the unit of time for the timeout duration
+     * @param timeout  timeout duration (ignored)
+     * @param timeUnit unit of the timeout (ignored)
      * @throws TimeoutException never thrown
      */
     @Override

--- a/src/main/java/net/openhft/chronicle/threads/BusyTimedPauser.java
+++ b/src/main/java/net/openhft/chronicle/threads/BusyTimedPauser.java
@@ -23,7 +23,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * Similar to {@link BusyPauser} but also supporting {@link TimingPauser}
+ * Busy-spin pauser that also implements {@link TimingPauser}.
+ * <p>
+ * Like {@link BusyPauser} it never yields or sleeps, so it occupies a CPU core
+ * while waiting. In addition it tracks elapsed busy-spin time and can throw a
+ * {@link TimeoutException} when a configured timeout is exceeded.
  */
 public class BusyTimedPauser implements Pauser, TimingPauser {
 
@@ -40,25 +44,31 @@ public class BusyTimedPauser implements Pauser, TimingPauser {
         return true;
     }
 
+    /**
+     * Clears any timeout state so the next timed pause starts afresh.
+     */
     @Override
     public void reset() {
         time = Long.MAX_VALUE;
     }
 
+    /**
+     * Busy-spins once and increments the pause count.
+     * No yielding or sleeping occurs.
+     */
     @Override
     public void pause() {
         countPaused++;
-        // busy wait.
         Jvm.nanoPause();
     }
 
     /**
-     * Attempts to pause the thread with a specified timeout. If the pause exceeds the specified duration,
-     * a {@link TimeoutException} is thrown, indicating the timeout has elapsed without resumption of operations.
+     * Busy-spins until the accumulated pause time exceeds the supplied timeout.
+     * The timer starts with the first call after {@link #reset()}.
      *
-     * @param timeout  the maximum time to wait before throwing an exception
-     * @param timeUnit the unit of time for the timeout parameter
-     * @throws TimeoutException if the wait exceeds the specified timeout duration
+     * @param timeout  maximum time to spin before throwing an exception
+     * @param timeUnit unit for {@code timeout}
+     * @throws TimeoutException if the time since the first call exceeds the timeout
      */
     @Override
     public void pause(long timeout, TimeUnit timeUnit) throws TimeoutException {


### PR DESCRIPTION
## Summary
- document that `BusyPauser` never yields or sleeps
- explain that `BusyTimedPauser` busy-spins but supports timeouts
- specify semantics of `pause()` and `pause(timeout, TimeUnit)`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*