### PR TITLE
Document thread monitors

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -237,6 +237,8 @@ Event Loop Monitoring (AKA Loop Block Monitoring) is a very useful feature. This
 by the `EventGroup`. The `ThreadMonitorHarness` handler monitors fast event loop threads to make sure event handler latency remains within acceptable bounds. The `ThreadMonitorHarness` monitors latency by measuring the time the `action` method of the application event handlers takes to run. Whenever the method runs beyond an acceptable latency limit, `ThreadMonitorHarness` prints a stack trace for the event loop thread.
 This output can be processed with tools to help identify hotspots in your program.
 
+Each monitored thread is wrapped by a `ThreadMonitor` created via the `ThreadMonitors` helper. The monitor loop runs these handlers at a fixed interval and compares the time since the thread last started work with the configured limit. When the limit is exceeded a stack trace of the target thread is logged, allowing blocked threads to be detected without halting the system.
+
 Set the monitor event interval with system property `MONITOR_INTERVAL_MS`.
 
 Disable the monitor by setting the system property:

--- a/src/main/java/net/openhft/chronicle/threads/ThreadMonitor.java
+++ b/src/main/java/net/openhft/chronicle/threads/ThreadMonitor.java
@@ -22,7 +22,15 @@ import net.openhft.chronicle.core.threads.EventHandler;
 import net.openhft.chronicle.core.threads.HandlerPriority;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Event handler used by the monitor loop to detect threads that appear to be
+ * blocked. Instances are typically produced by {@link ThreadMonitors}.
+ */
 public interface ThreadMonitor extends EventHandler {
+    /**
+     * Returns {@link HandlerPriority#MONITOR} so monitoring does not compete
+     * with application handlers.
+     */
     @Override
     default @NotNull HandlerPriority priority() {
         return HandlerPriority.MONITOR;

--- a/src/main/java/net/openhft/chronicle/threads/ThreadMonitors.java
+++ b/src/main/java/net/openhft/chronicle/threads/ThreadMonitors.java
@@ -31,8 +31,20 @@ import java.util.function.Supplier;
 public enum ThreadMonitors {
     ; // none
 
-    public static ThreadMonitor forThread(String description, long timeLimit, LongSupplier timeSupplier, Supplier<Thread> threadSupplier) {
-        return new ThreadMonitorHarness(new ThreadsThreadHolder(description, timeLimit, timeSupplier, threadSupplier, () -> true, perfOn()));
+    /**
+     * Create a monitor for a single thread.
+     *
+     * @param description   text used in log messages
+     * @param timeLimit     threshold in nanoseconds before a stack trace is logged
+     * @param timeSupplier  supplies the current time, usually {@link System#nanoTime}
+     * @param threadSupplier returns the thread to observe
+     * @return a monitor handler for installation on a monitor loop
+     */
+    public static ThreadMonitor forThread(String description, long timeLimit,
+                                          LongSupplier timeSupplier,
+                                          Supplier<Thread> threadSupplier) {
+        return new ThreadMonitorHarness(new ThreadsThreadHolder(description,
+                timeLimit, timeSupplier, threadSupplier, () -> true, perfOn()));
     }
 
     @NotNull
@@ -40,15 +52,61 @@ public enum ThreadMonitors {
         return msg -> Jvm.perf().on(ThreadMonitor.class, msg);
     }
 
-    public static ThreadMonitor forThread(String description, long timeLimit, LongSupplier timeSupplier, Supplier<Thread> threadSupplier, BooleanSupplier logEnabled, Consumer<String> logConsumer) {
-        return new ThreadMonitorHarness(new ThreadsThreadHolder(description, timeLimit, timeSupplier, threadSupplier, logEnabled, logConsumer));
+    /**
+     * Variant of {@link #forThread(String, long, LongSupplier, Supplier)} that
+     * allows the caller to control logging.
+     *
+     * @param description    text used in log messages
+     * @param timeLimit      threshold in nanoseconds before a stack trace is logged
+     * @param timeSupplier   supplies the current time
+     * @param threadSupplier returns the thread to observe
+     * @param logEnabled     predicate controlling whether logging occurs
+     * @param logConsumer    receives the formatted log message
+     * @return a monitor handler for installation on a monitor loop
+     */
+    public static ThreadMonitor forThread(String description, long timeLimit,
+                                          LongSupplier timeSupplier,
+                                          Supplier<Thread> threadSupplier,
+                                          BooleanSupplier logEnabled,
+                                          Consumer<String> logConsumer) {
+        return new ThreadMonitorHarness(new ThreadsThreadHolder(description,
+                timeLimit, timeSupplier, threadSupplier, logEnabled, logConsumer));
     }
 
-    public static ThreadMonitor forServices(String description, long timeLimit, LongSupplier timeSupplier, Supplier<Thread> threadSupplier) {
-        return new ThreadMonitorHarness(new ThreadsThreadHolder(description, timeLimit, timeSupplier, threadSupplier, () -> true, perfOn()));
+    /**
+     * Create a monitor aimed at a service thread.
+     *
+     * @param description   text used in log messages
+     * @param timeLimit     threshold in nanoseconds before a stack trace is logged
+     * @param timeSupplier  supplies the current time
+     * @param threadSupplier returns the thread to observe
+     * @return a monitor handler for installation on a monitor loop
+     */
+    public static ThreadMonitor forServices(String description, long timeLimit,
+                                            LongSupplier timeSupplier,
+                                            Supplier<Thread> threadSupplier) {
+        return new ThreadMonitorHarness(new ThreadsThreadHolder(description,
+                timeLimit, timeSupplier, threadSupplier, () -> true, perfOn()));
     }
 
-    public static ThreadMonitor forServices(String description, long timeLimit, LongSupplier timeSupplier, Supplier<Thread> threadSupplier, BooleanSupplier logEnabled, Consumer<String> logConsumer) {
-        return new ThreadMonitorHarness(new ThreadsThreadHolder(description, timeLimit, timeSupplier, threadSupplier, logEnabled, logConsumer));
+    /**
+     * Variant of {@link #forServices(String, long, LongSupplier, Supplier)} with
+     * caller controlled logging.
+     *
+     * @param description    text used in log messages
+     * @param timeLimit      threshold in nanoseconds before a stack trace is logged
+     * @param timeSupplier   supplies the current time
+     * @param threadSupplier returns the thread to observe
+     * @param logEnabled     predicate controlling whether logging occurs
+     * @param logConsumer    receives the formatted log message
+     * @return a monitor handler for installation on a monitor loop
+     */
+    public static ThreadMonitor forServices(String description, long timeLimit,
+                                            LongSupplier timeSupplier,
+                                            Supplier<Thread> threadSupplier,
+                                            BooleanSupplier logEnabled,
+                                            Consumer<String> logConsumer) {
+        return new ThreadMonitorHarness(new ThreadsThreadHolder(description,
+                timeLimit, timeSupplier, threadSupplier, logEnabled, logConsumer));
     }
 }


### PR DESCRIPTION
## Summary
- explain how the monitor loop detects blocked threads
- document `ThreadMonitor` and the `forThread` / `forServices` factory methods

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*