### PR TITLE
Document ExecutorFactory

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/ExecutorFactory.java
+++ b/src/main/java/net/openhft/chronicle/threads/ExecutorFactory.java
@@ -15,13 +15,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package net.openhft.chronicle.threads;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
+/**
+ * Strategy interface for obtaining {@link ExecutorService} instances.
+ *
+ * <p>The Chronicle Threads utility relies on this abstraction so that
+ * applications may plug in their own executor creation logic.  The
+ * supplied implementation can integrate with alternative concurrency
+ * frameworks or simply wrap the standard JDK executors.</p>
+ */
 public interface ExecutorFactory {
+
+    /**
+     * Creates or retrieves an {@link ExecutorService}.
+     *
+     * @param name    base name for the threads created by the executor
+     * @param threads requested thread count
+     * @param daemon  {@code true} if the threads should be daemon threads
+     * @return a service suitable for running general tasks
+     */
     ExecutorService acquireExecutorService(String name, int threads, boolean daemon);
 
+    /**
+     * Creates or retrieves a {@link ScheduledExecutorService}.
+     *
+     * @param name   base name for the threads created by the scheduler
+     * @param daemon {@code true} if the threads should be daemon threads
+     * @return a single-threaded scheduler
+     */
     ScheduledExecutorService acquireScheduledExecutorService(String name, boolean daemon);
 }

--- a/src/main/java/net/openhft/chronicle/threads/VanillaExecutorFactory.java
+++ b/src/main/java/net/openhft/chronicle/threads/VanillaExecutorFactory.java
@@ -15,16 +15,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package net.openhft.chronicle.threads;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
+/**
+ * Default {@link ExecutorFactory} used by Chronicle Threads.
+ *
+ * <p>It creates standard JDK executor services backed by a
+ * {@link NamedThreadFactory}.  Single thread requests result in a
+ * {@link java.util.concurrent.Executors#newSingleThreadExecutor single-thread}
+ * pool, otherwise a fixed thread pool is returned.  Scheduled executors are
+ * always single-threaded.</p>
+ */
 public enum VanillaExecutorFactory implements ExecutorFactory {
+    /** sole instance used by default */
     INSTANCE;
 
     @Override
+    /**
+     * Provides an executor backed by a {@link NamedThreadFactory}.  A single
+     * thread executor is created when {@code threads} equals one, otherwise a
+     * fixed thread pool is returned.
+     */
     public ExecutorService acquireExecutorService(String name, int threads, boolean daemon) {
         NamedThreadFactory threadFactory = new NamedThreadFactory(name, daemon);
         return threads == 1
@@ -33,6 +49,9 @@ public enum VanillaExecutorFactory implements ExecutorFactory {
     }
 
     @Override
+    /**
+     * Creates a single-thread {@link ScheduledExecutorService}.
+     */
     public ScheduledExecutorService acquireScheduledExecutorService(String name, boolean daemon) {
         return Executors.newSingleThreadScheduledExecutor(
                 new NamedThreadFactory(name, daemon));


### PR DESCRIPTION
## Summary
- explain the `ExecutorFactory` abstraction
- describe thread pool retrieval methods
- clarify what the default implementation provides

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*