### PR TITLE
Add Javadoc for EventHandlers enum

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/EventHandlers.java
+++ b/src/main/java/net/openhft/chronicle/threads/EventHandlers.java
@@ -20,6 +20,11 @@ package net.openhft.chronicle.threads;
 
 import net.openhft.chronicle.core.threads.EventHandler;
 
+/**
+ * Placeholder enum that holds simple {@link EventHandler} constants.
+ * The only entry is {@link #NOOP}, whose {@code action()} method always
+ * returns {@code false}.
+ */
 enum EventHandlers implements EventHandler {
     NOOP {
         @Override


### PR DESCRIPTION
## Notes
- Maven is not available, so `mvn verify` could not be run.

## Summary
- document that EventHandlers is a placeholder for basic handlers such as NOOP

## Testing
- `mvn -q verify` *(fails: mvn not found)*