### PR TITLE
Add licence header and Javadoc for NotifyDiskLow

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/NotifyDiskLow.java
+++ b/src/main/java/net/openhft/chronicle/threads/NotifyDiskLow.java
@@ -1,7 +1,36 @@
+/*
+ * Copyright 2016-2020 chronicle.software
+ *
+ *       https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.openhft.chronicle.threads;
 
 import java.nio.file.FileStore;
 
+/**
+ * Receives notifications from the disk space monitor.
+ *
+ * <p>The {@link #panic(FileStore)} method is called when a file store
+ * is critically short of space. Implementations should act immediately
+ * as memory-mapped writes may fail.</p>
+ *
+ * <p>The {@link #warning(double, FileStore)} method signals that a disk
+ * is nearing its limit. The percentage parameter denotes how full the disk
+ * currently is.</p>
+ */
 public interface NotifyDiskLow {
     void panic(FileStore fileStore);
 


### PR DESCRIPTION
## Summary
- add Apache licence header to `NotifyDiskLow`
- document panic and warning callbacks

## Testing
- `mvn -q verify` *(fails: mvn not found)*