### PR TITLE
Document ThreadHolder interface

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/ThreadHolder.java
+++ b/src/main/java/net/openhft/chronicle/threads/ThreadHolder.java
@@ -21,13 +21,30 @@ package net.openhft.chronicle.threads;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.threads.InvalidEventHandlerException;
 
+/**
+ * Supplies runtime details of a thread or event loop being monitored.  The
+ * associated {@link ThreadMonitor} uses this information to detect long blocks
+ * or unexpected thread termination.
+ */
 public interface ThreadHolder {
     int TIMING_ERROR = Jvm.getInteger("threads.timing.error", 80_000_000);
 
+    /**
+     * Indicates whether the monitored thread is still running.
+     *
+     * @return {@code true} if the thread has not terminated
+     * @throws InvalidEventHandlerException if the holder can no longer be queried
+     */
     boolean isAlive() throws InvalidEventHandlerException;
 
+    /**
+     * Called once the thread has ended so monitoring can be stopped or logged.
+     */
     void reportFinished();
 
+    /**
+     * Clears any internal timers when a new loop iteration begins.
+     */
     void resetTimers();
 
     /**
@@ -37,13 +54,38 @@ public interface ThreadHolder {
      */
     long startedNS();
 
+    /**
+     * Determines whether a block has exceeded the logging threshold.
+     *
+     * @param nowNS the current time in nanoseconds
+     * @return {@code true} if logging should occur
+     */
     boolean shouldLog(long nowNS);
 
+    /**
+     * Produces a diagnostic dump when a stall is detected.
+     *
+     * @param startedNS when the loop iteration began
+     * @param nowNS     the time the dump is triggered
+     */
     void dumpThread(long startedNS, long nowNS);
 
+    /**
+     * Descriptive name used in log output.
+     */
     String getName();
 
+    /**
+     * Notifies that the monitor thread itself was delayed.
+     *
+     * @param actionCallDelayNS time since the last monitor call in nanoseconds
+     */
     void monitorThreadDelayed(long actionCallDelayNS);
 
+    /**
+     * Maximum delay between monitor calls before a warning is triggered.
+     *
+     * @return tolerance in nanoseconds
+     */
     long timingToleranceNS();
 }


### PR DESCRIPTION
## Summary
- add interface level javadoc for `ThreadHolder`
- document lifecycle and monitoring methods

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*