### PR TITLE
Add Javadocs for thread utilities

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/Threads.java
+++ b/src/main/java/net/openhft/chronicle/threads/Threads.java
@@ -36,6 +36,13 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
+/**
+ * Miscellaneous helper methods for thread and executor management.
+ *
+ * <p>The enum acts as a static holder and exposes utilities to acquire and
+ * shut down executor services, inspect running threads and assist with
+ * event loop execution.</p>
+ */
 public enum Threads {
     ; // none
 
@@ -56,18 +63,43 @@ public enum Threads {
         executorFactory = instance;
     }
 
+    /**
+     * Acquire an executor service from the current factory.
+     *
+     * @param name    prefix used when naming threads
+     * @param threads number of worker threads
+     * @param daemon  whether the threads should be daemons
+     * @return the executor service to use
+     */
     public static ExecutorService acquireExecutorService(String name, int threads, boolean daemon) {
         return executorFactory.acquireExecutorService(name, threads, daemon);
     }
 
+    /**
+     * Acquire a scheduled executor service from the current factory.
+     *
+     * @param name   prefix used when naming threads
+     * @param daemon whether the threads should be daemons
+     * @return the scheduled executor service
+     */
     public static ScheduledExecutorService acquireScheduledExecutorService(String name, boolean daemon) {
         return executorFactory.acquireScheduledExecutorService(name, daemon);
     }
 
+    /**
+     * Install an alternative factory used to create executors.
+     *
+     * @param executorFactory provider used henceforth
+     */
     public static void executorFactory(ExecutorFactory executorFactory) {
         Threads.executorFactory = executorFactory;
     }
 
+    /**
+     * Return the current thread group name with a trailing slash.
+     *
+     * @return thread group prefix
+     */
     @NotNull
     public static String threadGroupPrefix() {
         String threadGroupName = Thread.currentThread().getThreadGroup().getName();
@@ -101,6 +133,12 @@ public enum Threads {
         }
     }
 
+    /**
+     * Shutdown the service according to the daemon flag.
+     *
+     * @param service the executor to close
+     * @param daemon  invoke {@link #shutdownDaemon(ExecutorService)} when true
+     */
     public static void shutdown(@NotNull ExecutorService service, boolean daemon) {
         if (daemon)
             shutdownDaemon(service);
@@ -160,10 +198,20 @@ public enum Threads {
             stringBuilder.append("  ").append(s).append("\n");
     }
 
+    /**
+     * Unpark all threads belonging to the service.
+     *
+     * @param service executor whose threads should be unparked
+     */
     public static void unpark(ExecutorService service) {
         forEachThread(service, LockSupport::unpark);
     }
 
+    /**
+     * Interrupt all threads managed by the service.
+     *
+     * @param service executor whose threads should be interrupted
+     */
     public static void interrupt(ExecutorService service) {
         Threads.forEachThread(service, Thread::interrupt);
     }


### PR DESCRIPTION
## Summary
- document helper methods in `Threads`
- add Javadoc for executor service acquisition and shutdown helpers

## Testing
- `mvn -q verify` *(fails: command not found)*