### PR TITLE
Document accept handler constants

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/internal/EventLoopUtil.java
+++ b/src/main/java/net/openhft/chronicle/threads/internal/EventLoopUtil.java
@@ -19,9 +19,26 @@ package net.openhft.chronicle.threads.internal;
 
 import net.openhft.chronicle.core.Jvm;
 
+/**
+ * Configuration values for event loop behaviour.
+ *
+ * <p>The {@code ACCEPT_HANDLER_MOD_COUNT} system property specifies how often
+ * new accept handlers are inserted to avoid starvation. A value of zero
+ * disables this feature. If the property is absent the
+ * {@link #DEFAULT_ACCEPT_HANDLER_MOD_COUNT default} is used. The
+ * {@link #IS_ACCEPT_HANDLER_MOD_COUNT} flag reveals whether re-arming is
+ * enabled.</p>
+ */
 public enum EventLoopUtil {
     ; // none
+
+    /** Fallback when {@code eventloop.accept.mod} is not set. */
     private static final int DEFAULT_ACCEPT_HANDLER_MOD_COUNT = 128;
-    public static final int ACCEPT_HANDLER_MOD_COUNT = Jvm.getInteger("eventloop.accept.mod", DEFAULT_ACCEPT_HANDLER_MOD_COUNT);
+
+    /** Interval for re-adding accept handlers. */
+    public static final int ACCEPT_HANDLER_MOD_COUNT =
+            Jvm.getInteger("eventloop.accept.mod", DEFAULT_ACCEPT_HANDLER_MOD_COUNT);
+
+    /** True when accept handler re-arming is active. */
     public static final boolean IS_ACCEPT_HANDLER_MOD_COUNT = ACCEPT_HANDLER_MOD_COUNT > 0;
 }


### PR DESCRIPTION
## Summary
- add Javadoc to explain event loop configuration constants

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*