### PR TITLE
Add Javadoc for BlockingEventLoopTest

### DIFF
--- a/src/test/java/net/openhft/chronicle/threads/BlockingEventLoopTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/BlockingEventLoopTest.java
@@ -31,6 +31,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * Verifies that a handler in a {@link BlockingEventLoop} is interrupted when
+ * the loop is stopped while the calling thread continues unimpeded.
+ */
 public class BlockingEventLoopTest extends ThreadsTestCommon {
 
     @Test


### PR DESCRIPTION
## Summary
- describe test verifying interrupt behaviour for handlers when a blocking event loop is stopped

## Testing
- `mvn -q verify` *(fails: command not found)*