### PR TITLE
Add Javadoc explaining invalid affinity test

### DIFF
--- a/src/test/java/net/openhft/chronicle/threads/EventGroupBadAffinityTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventGroupBadAffinityTest.java
@@ -28,6 +28,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class EventGroupBadAffinityTest extends ThreadsTestCommon {
 
+    /**
+     * Ensures that an invalid CPU affinity string fails fast so that
+     * misconfigured deployments do not run with unexpected processor binding.
+     */
     @Timeout(5_000)
     @Test
     public void testInvalidAffinity() {


### PR DESCRIPTION
## Summary
- document the purpose of `EventGroupBadAffinityTest#testInvalidAffinity`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*