### PR TITLE
Add Javadoc to EventLoopsTest

### DIFF
--- a/src/test/java/net/openhft/chronicle/threads/EventLoopsTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventLoopsTest.java
@@ -40,6 +40,15 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * Exercises the helper routines in {@link EventLoops} and the life-cycle
+ * checks in {@link EventLoop}.
+ * <p>
+ * The tests confirm that {@link EventLoops#stopAll(Object...)} accepts
+ * {@code null} values and waits for every loop to stop. They also verify
+ * that calling {@link EventLoop#close()} from the loop's own thread triggers
+ * a {@link ThreadingIllegalStateException}.
+ */
 public class EventLoopsTest extends ThreadsTestCommon {
 
     @Test


### PR DESCRIPTION
## Summary
- document the EventLoopsTest utility coverage

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*