### PR TITLE
Document LongPauser behaviour under test

### DIFF
--- a/src/test/java/net/openhft/chronicle/threads/LongPauserTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/LongPauserTest.java
@@ -26,6 +26,19 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Tests the pausing behaviour of {@link LongPauser}.
+ *
+ * <p>These tests ensure that:
+ * <ul>
+ *   <li>{@link LongPauser#unpause()} releases a thread blocked in
+ *       {@link LongPauser#pause()} promptly.</li>
+ *   <li>{@link LongPauser#asyncPause()} waits for roughly the configured
+ *       duration before clearing.</li>
+ *   <li>{@link LongPauser#reset()} cancels any pending asynchronous
+ *       pause.</li>
+ * </ul>
+ */
 public class LongPauserTest extends ThreadsTestCommon {
 
     @Test


### PR DESCRIPTION
## Notes
- `mvn` was not available in the environment, so the build could not be run.

## Summary
- add a class-level Javadoc describing what aspects of `LongPauser` are exercised by the tests