### PR TITLE
Document MediumEventLoop behaviour

### DIFF
--- a/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
@@ -18,6 +18,15 @@
 
 package net.openhft.chronicle.threads;
 
+/**
+ * Tests the expected behaviour of {@link MediumEventLoop}.
+ *
+ * <p>Handlers may be registered before or after the loop starts. Those that
+ * throw from lifecycle methods are removed and closed without stopping the
+ * loop. Concurrent start and stop calls from separate threads should succeed
+ * without error.
+ */
+
 import net.openhft.chronicle.core.io.InvalidMarshallableException;
 import net.openhft.chronicle.core.threads.EventHandler;
 import net.openhft.chronicle.core.threads.HandlerPriority;


### PR DESCRIPTION
## Summary
- clarify MediumEventLoop behaviour in MediumEventLoopTest

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*