### PR TITLE
Add Javadoc for test helper handlers

### DIFF
--- a/src/test/java/net/openhft/chronicle/threads/TestEventHandlers.java
+++ b/src/test/java/net/openhft/chronicle/threads/TestEventHandlers.java
@@ -29,6 +29,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class TestEventHandlers {
 
+    /**
+     * Utility handler used in tests. Counts how many times each lifecycle
+     * method is invoked.
+     */
     public static class CountingHandler implements EventHandler, Closeable {
         protected final AtomicInteger loopStartedCalled = new AtomicInteger();
         protected final AtomicInteger loopFinishedCalled = new AtomicInteger();
@@ -99,6 +103,10 @@ public class TestEventHandlers {
     public static final String HANDLER_EVENT_LOOP_EXCEPTION_TXT = "Something went wrong in set eventLoop!!!";
     public static final String HANDLER_PRIORITY_EXCEPTION_TXT = "Something went wrong in priority!!!";
 
+    /**
+     * Handler that throws from selected lifecycle methods so tests can
+     * exercise error paths in the event loop.
+     */
     public static class ThrowingHandler extends CountingHandler {
         protected final boolean throwsEventLoop;
         protected final boolean throwsPriority;


### PR DESCRIPTION
## Summary
- document CountingHandler and ThrowingHandler helper classes used in tests

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*