### PR TITLE
DEV-227 - Adds logging for DEBUG_REMOVING_HANDLERS system property

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/BlockingEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/BlockingEventLoop.java
@@ -73,7 +73,7 @@ public class BlockingEventLoop extends AbstractLifecycleEventLoop implements Eve
     @Override
     public synchronized void addHandler(@NotNull final EventHandler handler) {
         if (DEBUG_ADDING_HANDLERS)
-            Jvm.startup().on(getClass(), "Adding " + handler.priority() + " " + handler + " to " + this.name);
+            Jvm.debug().on(getClass(), "Adding " + handler.priority() + " " + handler + " to " + this.name);
         if (isClosed())
             throw new IllegalStateException("Event Group has been closed");
         eventLoopQuietly(parent, handler);

--- a/src/main/java/net/openhft/chronicle/threads/BlockingEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/BlockingEventLoop.java
@@ -192,7 +192,7 @@ public class BlockingEventLoop extends AbstractLifecycleEventLoop implements Eve
                 if (!endedGracefully) {
                     // remove handler for clarity when debugging
                     if (DEBUG_REMOVING_HANDLERS)
-                        Jvm.perf().on(getClass(), "Removing " + handler.priority() + " " + handler);
+                        Jvm.debug().on(getClass(), "Removing " + handler.priority() + " " + handler);
                     handlers.remove(handler);
                     closeQuietly(handler);
                 }

--- a/src/main/java/net/openhft/chronicle/threads/BlockingEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/BlockingEventLoop.java
@@ -191,6 +191,8 @@ public class BlockingEventLoop extends AbstractLifecycleEventLoop implements Eve
                 loopFinishedQuietly(handler);
                 if (!endedGracefully) {
                     // remove handler for clarity when debugging
+                    if (DEBUG_REMOVING_HANDLERS)
+                        Jvm.perf().on(getClass(), "Removing " + handler.priority() + " " + handler);
                     handlers.remove(handler);
                     closeQuietly(handler);
                 }

--- a/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
@@ -115,6 +115,8 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
         loopFinishedQuietly(handler);
         Closeable.closeQuietly(handler);
         try {
+            if (DEBUG_REMOVING_HANDLERS)
+                Jvm.perf().on(MediumEventLoop.class, "Removing " + handler.priority() + " " + handler);
             handlers.remove(handler);
         } catch (ArrayIndexOutOfBoundsException e2) {
             if (!handlers.isEmpty())
@@ -500,6 +502,8 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
     }
 
    protected void removeHighHandler() {
+       if (DEBUG_REMOVING_HANDLERS)
+           Jvm.perf().on(getClass(), "Removing " + highHandler.priority() + " " + highHandler + " from " + this.name);
         Threads.loopFinishedQuietly(highHandler);
         Closeable.closeQuietly(highHandler);
         highHandler = EventHandlers.NOOP;

--- a/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
@@ -186,7 +186,7 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
 
         final HandlerPriority priority = handler.priority().alias();
         if (DEBUG_ADDING_HANDLERS)
-            Jvm.startup().on(getClass(), "Adding " + priority + " " + handler + " to " + this.name);
+            Jvm.debug().on(getClass(), "Adding " + priority + " " + handler + " to " + this.name);
         if (!ALLOWED_PRIORITIES.contains(priority)) {
             if (handler.priority() == HandlerPriority.MONITOR) {
                 Jvm.warn().on(getClass(), "Ignoring " + handler.getClass());

--- a/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
@@ -116,7 +116,7 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
         Closeable.closeQuietly(handler);
         try {
             if (DEBUG_REMOVING_HANDLERS)
-                Jvm.perf().on(MediumEventLoop.class, "Removing " + handler.priority() + " " + handler);
+                Jvm.debug().on(MediumEventLoop.class, "Removing " + handler.priority() + " " + handler);
             handlers.remove(handler);
         } catch (ArrayIndexOutOfBoundsException e2) {
             if (!handlers.isEmpty())
@@ -503,7 +503,7 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
 
    protected void removeHighHandler() {
        if (DEBUG_REMOVING_HANDLERS)
-           Jvm.perf().on(getClass(), "Removing " + highHandler.priority() + " " + highHandler + " from " + this.name);
+           Jvm.debug().on(getClass(), "Removing " + highHandler.priority() + " " + highHandler + " from " + this.name);
         Threads.loopFinishedQuietly(highHandler);
         Closeable.closeQuietly(highHandler);
         highHandler = EventHandlers.NOOP;

--- a/src/main/java/net/openhft/chronicle/threads/MonitorEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MonitorEventLoop.java
@@ -154,7 +154,7 @@ public class MonitorEventLoop extends AbstractLifecycleEventLoop implements Runn
             loopFinishedQuietly(removedHandler);
             Closeable.closeQuietly(removedHandler);
             if (DEBUG_REMOVING_HANDLERS)
-                Jvm.perf().on(getClass(), "Removing " + removedHandler.priority() + " " + removedHandler + " from " + this.name);
+                Jvm.debug().on(getClass(), "Removing " + removedHandler.priority() + " " + removedHandler + " from " + this.name);
         } catch (ArrayIndexOutOfBoundsException e) {
             if (!handlers.isEmpty()) {
                 Jvm.warn().on(MonitorEventLoop.class, "Error removing handler!");

--- a/src/main/java/net/openhft/chronicle/threads/MonitorEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MonitorEventLoop.java
@@ -153,6 +153,8 @@ public class MonitorEventLoop extends AbstractLifecycleEventLoop implements Runn
             EventHandler removedHandler = handlers.remove(handlerIndex);
             loopFinishedQuietly(removedHandler);
             Closeable.closeQuietly(removedHandler);
+            if (DEBUG_REMOVING_HANDLERS)
+                Jvm.perf().on(getClass(), "Removing " + removedHandler.priority() + " " + removedHandler + " from " + this.name);
         } catch (ArrayIndexOutOfBoundsException e) {
             if (!handlers.isEmpty()) {
                 Jvm.warn().on(MonitorEventLoop.class, "Error removing handler!");

--- a/src/main/java/net/openhft/chronicle/threads/MonitorEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MonitorEventLoop.java
@@ -91,7 +91,7 @@ public class MonitorEventLoop extends AbstractLifecycleEventLoop implements Runn
         throwExceptionIfClosed();
 
         if (DEBUG_ADDING_HANDLERS)
-            Jvm.startup().on(getClass(), "Adding " + handler.priority() + " " + handler + " to " + this.name);
+            Jvm.debug().on(getClass(), "Adding " + handler.priority() + " " + handler + " to " + this.name);
         if (isClosed())
             throw new IllegalStateException("Event Group has been closed");
         eventLoopQuietly(parent, handler);

--- a/src/main/java/net/openhft/chronicle/threads/VanillaEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/VanillaEventLoop.java
@@ -99,7 +99,7 @@ public class VanillaEventLoop extends MediumEventLoop {
 
         final HandlerPriority priority = handler.priority();
         if (DEBUG_ADDING_HANDLERS)
-            Jvm.startup().on(getClass(), "Adding " + priority + " " + handler + " to " + this.name);
+            Jvm.debug().on(getClass(), "Adding " + priority + " " + handler + " to " + this.name);
         if (!priorities.contains(priority))
             throw new IllegalStateException(name() + ": Unexpected priority " + priority + " for " + handler + " allows " + priorities);
         addHandlerInternal(handler);


### PR DESCRIPTION
# Debug Removing Handlers Property

https://chroniclesoftware.atlassian.net/browse/DEV-227

https://chroniclesoftware.happyfox.com/staff/ticket/3114

</br>

## Testing

### Steps:
1. Checkout [`chronicle-core` -> `feature/debug-removing-handlers-property`](https://github.com/OpenHFT/Chronicle-Core/pull/816) and run a `mvn clean install`

2. Checkout `chronicle-threads` -> `feature/debug-removing-handlers-property` and run a `mvn clean install`

3. In the Chronicle-Threads/pom.xml Line 68, add an explicit version to the already existing chronicle-core dependency:

Before: 

```
<dependency>
    <groupId>net.openhft</groupId>
    <artifactId>chronicle-core</artifactId>
</dependency> 
```

After:
```
<dependency>
    <groupId>net.openhft</groupId>
    <artifactId>chronicle-core</artifactId>
    <version>2.27ea3-SNAPSHOT</version>
</dependency> 
```

4. In Chronicle-Threads EventGroupTest.java add the following code block:
    
```
    @BeforeAll
    public static void init() {
        System.setProperty("debug.adding.handlers", "true");
        System.setProperty("debug.removing.handlers", "true");
        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "debug");
    }
```

5. Run EventGroupTest.checkAllEventHandlerTypesStartInvalidEventHandlerException() - this will hit all 4 of the newly added log outputs

6. Ensure that all 4 log outputs are printed successfully and are formatted correctly