### PR TITLE
Allow short-lived “private” EventGroups to self-shutdown from within

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/AbstractLifecycleEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/AbstractLifecycleEventLoop.java
@@ -47,6 +47,7 @@ public abstract class AbstractLifecycleEventLoop extends AbstractCloseable imple
     private static final long AWAIT_TERMINATION_TIMEOUT_MS = TimeUnit.MINUTES.toMillis(5);
     private final AtomicReference<EventLoopLifecycle> lifecycle = new AtomicReference<>(EventLoopLifecycle.NEW);
     protected final String name;
+    private boolean privateGroup;
 
     protected AbstractLifecycleEventLoop(@NotNull String name) {
         this.name = name.replaceAll("/$", "");
@@ -126,8 +127,8 @@ public abstract class AbstractLifecycleEventLoop extends AbstractCloseable imple
 
     @Override
     protected void assertCloseable() {
-        if (isRunningOnThread(Thread.currentThread())) {
-            throw new ThreadingIllegalStateException("Attempting to close " + name + " from within!", null);
+        if (!privateGroup && isRunningOnThread(Thread.currentThread())) {
+            throw new ThreadingIllegalStateException(getClass() + ": Attempting to close " + name + " from within!", createdHere());
         }
     }
 
@@ -144,5 +145,9 @@ public abstract class AbstractLifecycleEventLoop extends AbstractCloseable imple
 
     static String withSlash(String n) {
         return n.isEmpty() ? n : n + "/";
+    }
+
+    public void privateGroup(boolean privateGroup) {
+        this.privateGroup = privateGroup;
     }
 }

--- a/src/main/java/net/openhft/chronicle/threads/CoreEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/CoreEventLoop.java
@@ -45,4 +45,6 @@ public interface CoreEventLoop extends EventLoop {
     void dumpRunningState(@NotNull final String message, @NotNull final BooleanSupplier finalCheck);
 
     boolean isRunningOnThread(Thread thread);
+
+    void privateGroup(boolean privateGroup);
 }

--- a/src/main/java/net/openhft/chronicle/threads/EventGroup.java
+++ b/src/main/java/net/openhft/chronicle/threads/EventGroup.java
@@ -359,4 +359,12 @@ public class EventGroup
                blocking != null && blocking.isRunningOnThread(thread) ||
                monitor.isRunningOnThread(thread);
     }
+
+    @Override
+    public void privateGroup(boolean privateGroup) {
+        super.privateGroup(privateGroup);
+        if (core != null) {
+            core.privateGroup(privateGroup);
+        }
+    }
 }

--- a/src/main/java/net/openhft/chronicle/threads/EventGroupBuilder.java
+++ b/src/main/java/net/openhft/chronicle/threads/EventGroupBuilder.java
@@ -50,6 +50,7 @@ public class EventGroupBuilder implements Builder<EventLoop> {
     private String defaultBinding = "none";
     @NotNull
     private Supplier<Pauser> blockingPauserSupplier = PauserMode.balanced;
+    private boolean privateGroup;
 
     public static EventGroupBuilder builder() {
         return new EventGroupBuilder();
@@ -61,7 +62,7 @@ public class EventGroupBuilder implements Builder<EventLoop> {
     @SuppressWarnings("deprecation")
     @Override
     public EventGroup build() {
-        return new EventGroup(daemon,
+        EventGroup eventGroup = new EventGroup(daemon,
                 pauserOrDefault(),
                 replicationPauser,
                 defaultBinding(binding),
@@ -72,6 +73,8 @@ public class EventGroupBuilder implements Builder<EventLoop> {
                 concurrentPauserSupplier,
                 priorities,
                 blockingPauserSupplier);
+        eventGroup.privateGroup(privateGroup);
+        return eventGroup;
     }
 
     @NotNull
@@ -150,5 +153,13 @@ public class EventGroupBuilder implements Builder<EventLoop> {
 
     public EventGroupBuilder withPriorities(HandlerPriority firstPriority, HandlerPriority... priorities) {
         return withPriorities(EnumSet.of(firstPriority, priorities));
+    }
+
+    /**
+     * Signifies this a private EventGroup, which will not be shared and can be shutdown independently.
+     */
+    public EventGroupBuilder withPrivateGroup(boolean privateGroup) {
+        this.privateGroup = privateGroup;
+        return this;
     }
 }

--- a/src/test/java/net/openhft/chronicle/threads/EventGroupTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventGroupTest.java
@@ -122,6 +122,35 @@ public class EventGroupTest extends ThreadsTestCommon {
 
     @Timeout(5)
     @Test
+    public void testSimpleEventGroupPrivateGroup() {
+        doTestSimpleEventGroup(true);
+    }
+
+    @Timeout(5)
+    @Test
+    public void testSimpleEventGroupNonPrivateGroup() {
+        doTestSimpleEventGroup(false);
+    }
+
+    public void doTestSimpleEventGroup(boolean privateGroup) {
+        if (!privateGroup)
+            expectException("Attempting to close private:false from within!");
+        try (final EventLoop eventGroup = EventGroup.builder()
+                .withName("private:" + privateGroup)
+                .withPriorities(HandlerPriority.MEDIUM)
+                .withPrivateGroup(privateGroup)
+                .withPauser(Pauser.millis(10))
+                .build()) {
+            eventGroup.start();
+            eventGroup.addHandler(() -> {
+                eventGroup.close();
+                return false;
+            });
+        }
+    }
+
+    @Timeout(5)
+    @Test
     public void testClosePausedBlockingEventLoop() {
         final EventLoop eventGroup = EventGroup.builder().build();
         eventGroup.start();
@@ -438,11 +467,11 @@ public class EventGroupTest extends ThreadsTestCommon {
 
     static Stream<List<HandlerPriority>> egCloseParams() {
         return Stream.of(
-               Arrays.asList(HandlerPriority.MEDIUM),
-               Arrays.asList(HandlerPriority.MEDIUM, HandlerPriority.HIGH),
-               Arrays.asList(HandlerPriority.TIMER, HandlerPriority.HIGH),
-               Arrays.asList(HandlerPriority.MEDIUM, HandlerPriority.BLOCKING, HandlerPriority.TIMER),
-               Arrays.asList(HandlerPriority.MEDIUM, HandlerPriority.BLOCKING, HandlerPriority.TIMER, HandlerPriority.HIGH)
+                Arrays.asList(HandlerPriority.MEDIUM),
+                Arrays.asList(HandlerPriority.MEDIUM, HandlerPriority.HIGH),
+                Arrays.asList(HandlerPriority.TIMER, HandlerPriority.HIGH),
+                Arrays.asList(HandlerPriority.MEDIUM, HandlerPriority.BLOCKING, HandlerPriority.TIMER),
+                Arrays.asList(HandlerPriority.MEDIUM, HandlerPriority.BLOCKING, HandlerPriority.TIMER, HandlerPriority.HIGH)
         );
     }
 

--- a/src/test/java/net/openhft/chronicle/threads/EventGroupTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventGroupTest.java
@@ -18,10 +18,7 @@
 package net.openhft.chronicle.threads;
 
 import net.openhft.chronicle.core.Jvm;
-import net.openhft.chronicle.core.io.AbstractCloseable;
-import net.openhft.chronicle.core.io.InvalidMarshallableException;
-import net.openhft.chronicle.core.io.SimpleCloseable;
-import net.openhft.chronicle.core.io.ThreadingIllegalStateException;
+import net.openhft.chronicle.core.io.*;
 import net.openhft.chronicle.core.threads.*;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
@@ -31,7 +28,6 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.io.Closeable;
 import java.util.*;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CountDownLatch;
@@ -143,7 +139,7 @@ public class EventGroupTest extends ThreadsTestCommon {
                 .build()) {
             eventGroup.start();
             eventGroup.addHandler(() -> {
-                eventGroup.close();
+                closeQuietly(eventGroup);
                 return false;
             });
         }


### PR DESCRIPTION
Introduce a **private group** mode for `EventGroup`s intended to be short-lived and not shared. When enabled, handlers running on the group’s own thread may legally trigger shutdown from inside the loop. By default nothing changes: standard groups remain long-lived and still reject in-loop shutdown attempts.

## Motivation

Some subsystems (e.g., ephemeral discovery, warm-up probes, conditional one-shot tasks) spin up an `EventGroup`, quickly determine it isn’t needed, and should tear it down immediately. Today, groups are designed to be long-lived; attempts to close from within the loop throw, forcing awkward out-of-band signalling. This PR provides a first-class, explicit escape hatch for these short-lived cases.

## What changed

* **`AbstractLifecycleEventLoop`**

  * Add `private boolean privateGroup;` and setter `privateGroup(boolean)`.
  * Relax in-loop close guard: only throw when **not** a private group.

    ```java
    if (!privateGroup && isRunningOnThread(Thread.currentThread())) {
        throw new ThreadingIllegalStateException(getClass() + ": Attempting to close " + name + " from within!", createdHere());
    }
    ```
  * Improve exception context: include `getClass()` and `createdHere()`.

* **`CoreEventLoop` (interface)**

  * Add `void privateGroup(boolean privateGroup);` to allow propagation of the mode.

* **`EventGroup`**

  * Override `privateGroup(boolean)` and propagate to `core` if present.

* **`EventGroupBuilder`**

  * Add builder flag `private boolean privateGroup;`
  * New fluent API: `withPrivateGroup(boolean privateGroup)`
  * Apply the flag during build: `eventGroup.privateGroup(privateGroup);`

## Behaviour & compatibility

* **Default behaviour unchanged.** `privateGroup` is `false` unless set; in-loop close attempts still throw.
* **Private groups:** When `withPrivateGroup(true)` is used, a handler running on the group’s own thread may call `close()` without tripping the guard.
* **API note:** Adding a method to `CoreEventLoop` is a **source/binary breaking change** for third-party implementations. Chronicle-maintained implementers are updated in this repo; external implementers must add a matching method.

## Usage example

```java
EventGroup eg = EventGroupBuilder.builder()
        .withPrivateGroup(true)   // short-lived, not shared
        // other config...
        .build();

eg.start();

// Inside a handler running on eg’s thread:
if (notNeeded()) {
    eg.close(); // now legal for private groups
}
```

## Rationale (problem → fix → impact)

* **Problem:** Ephemeral groups needed to tear down from within the loop, but the framework prevented it, requiring extra signalling logic.
* **Fix:** Introduce an explicit “private group” mode and relax the in-loop close assertion only for that mode. Provide builder plumbing and propagation so all constituent loops share the same policy.
* **Impact:** Cleaner, deterministic shutdown for short-lived, non-shared groups; no change for standard long-lived groups.