### PR TITLE
Fast shutdown for private EventGroups in MediumEventLoop; tidy-ups

### DIFF
--- a/src/main/java/net/openhft/chronicle/threads/AbstractLifecycleEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/AbstractLifecycleEventLoop.java
@@ -47,7 +47,7 @@ public abstract class AbstractLifecycleEventLoop extends AbstractCloseable imple
     private static final long AWAIT_TERMINATION_TIMEOUT_MS = TimeUnit.MINUTES.toMillis(5);
     private final AtomicReference<EventLoopLifecycle> lifecycle = new AtomicReference<>(EventLoopLifecycle.NEW);
     protected final String name;
-    private boolean privateGroup;
+    boolean privateGroup;
 
     protected AbstractLifecycleEventLoop(@NotNull String name) {
         this.name = name.replaceAll("/$", "");

--- a/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
@@ -680,6 +680,11 @@ public class MediumEventLoop extends AbstractLifecycleEventLoop implements CoreE
 
     private void shutdownService() {
         LockSupport.unpark(thread);
+        if (privateGroup) {
+            service.shutdownNow();
+            return;
+        }
+
         Threads.shutdown(service, daemon);
         if (thread != null && thread != Thread.currentThread()) {
             long startTimeMillis = System.currentTimeMillis();

--- a/src/main/java/net/openhft/chronicle/threads/MonitorEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MonitorEventLoop.java
@@ -19,8 +19,8 @@ package net.openhft.chronicle.threads;
 
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.annotation.HotMethod;
-import net.openhft.chronicle.core.io.AbstractCloseable;
 import net.openhft.chronicle.core.io.Closeable;
+import net.openhft.chronicle.core.io.SimpleCloseable;
 import net.openhft.chronicle.core.threads.EventHandler;
 import net.openhft.chronicle.core.threads.EventLoop;
 import net.openhft.chronicle.core.threads.HandlerPriority;
@@ -180,7 +180,7 @@ public class MonitorEventLoop extends AbstractLifecycleEventLoop implements Runn
      * easy way to achieve that is to wrap the handler in this idempotent decorator and
      * call it at the start of every iteration.
      */
-    private static final class IdempotentLoopStartedEventHandler extends AbstractCloseable implements EventHandler {
+    private static final class IdempotentLoopStartedEventHandler extends SimpleCloseable implements EventHandler {
 
         private transient final EventHandler eventHandler;
         private final String handler;


### PR DESCRIPTION
This PR refines the new **private EventGroup** flow by:

* Enabling a **fast teardown path** in `MediumEventLoop` (`shutdownNow()` when `privateGroup` is true).
* Allowing package-level access to the `privateGroup` flag for event loops.
* Simplifying a monitoring helper to use `SimpleCloseable`.

Default behaviour for normal, long-lived groups is unchanged.

## Motivation

Private groups are short-lived, and can be shutdown inside the EventLoop itself so it does work to wait for the thread to finish in the thread it's shutting down.  We also tidy up a small utility handler to reduce overhead.

## Changes

### `AbstractLifecycleEventLoop`

* **Visibility:** `private boolean privateGroup` → `boolean privateGroup` (package-private).

  * Rationale: allow same-package loops to consult the flag without accessor overhead.
  * Thread-safety: the flag is configured prior to start and not mutated thereafter.

### `MediumEventLoop`

* **Fast shutdown path** in `shutdownService()`:

  ```java
  LockSupport.unpark(thread);
  if (privateGroup) {
      service.shutdownNow();
      return;
  }
  Threads.shutdown(service, daemon);
  // ... existing join/wait logic ...
  ```

  * Effect: private groups stop aggressively and return immediately; standard groups continue to use graceful shutdown + await.

### `MonitorEventLoop`

* **Lightweight closeable:** `IdempotentLoopStartedEventHandler` now extends `SimpleCloseable` instead of `AbstractCloseable`.

  * Rationale: keep idempotent close semantics with less overhead (no allocation of creation traces), which is appropriate for a tiny decorator used on the hot path.