### PR TITLE
docs: bump copyright year end to 2026

### DIFF
--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -1,5 +1,5 @@
 
-== Copyright 2016-2025 chronicle.software
+== Copyright 2016-2026 chronicle.software
 
 Licensed under the *Apache License, Version 2.0* (the "License");
 you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+    Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 
 -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <packaging>bundle</packaging>
 
     <properties>
+        <license.year>2013-2026</license.year>
         <jacoco.line.coverage>0.7</jacoco.line.coverage>
         <jacoco.branch.coverage>0.6</jacoco.branch.coverage>
     </properties>

--- a/src/main/java/net/openhft/chronicle/threads/AbstractLifecycleEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/AbstractLifecycleEventLoop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/BlockingEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/BlockingEventLoop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/BusyPauser.java
+++ b/src/main/java/net/openhft/chronicle/threads/BusyPauser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/BusyTimedPauser.java
+++ b/src/main/java/net/openhft/chronicle/threads/BusyTimedPauser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/CoreEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/CoreEventLoop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/DiskSpaceMonitor.java
+++ b/src/main/java/net/openhft/chronicle/threads/DiskSpaceMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/EventGroup.java
+++ b/src/main/java/net/openhft/chronicle/threads/EventGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/EventGroupBuilder.java
+++ b/src/main/java/net/openhft/chronicle/threads/EventGroupBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/EventHandlers.java
+++ b/src/main/java/net/openhft/chronicle/threads/EventHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/EventLoopLifecycle.java
+++ b/src/main/java/net/openhft/chronicle/threads/EventLoopLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/EventLoops.java
+++ b/src/main/java/net/openhft/chronicle/threads/EventLoops.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/ExecutorFactory.java
+++ b/src/main/java/net/openhft/chronicle/threads/ExecutorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/LongPauser.java
+++ b/src/main/java/net/openhft/chronicle/threads/LongPauser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MediumEventLoop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/MilliPauser.java
+++ b/src/main/java/net/openhft/chronicle/threads/MilliPauser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/MonitorEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/MonitorEventLoop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/NamedThreadFactory.java
+++ b/src/main/java/net/openhft/chronicle/threads/NamedThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/NotifyDiskLow.java
+++ b/src/main/java/net/openhft/chronicle/threads/NotifyDiskLow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/NotifyDiskLowLogWarn.java
+++ b/src/main/java/net/openhft/chronicle/threads/NotifyDiskLowLogWarn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/Pauser.java
+++ b/src/main/java/net/openhft/chronicle/threads/Pauser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/PauserMode.java
+++ b/src/main/java/net/openhft/chronicle/threads/PauserMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/PauserMonitorFactory.java
+++ b/src/main/java/net/openhft/chronicle/threads/PauserMonitorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/ThreadHolder.java
+++ b/src/main/java/net/openhft/chronicle/threads/ThreadHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/ThreadMonitor.java
+++ b/src/main/java/net/openhft/chronicle/threads/ThreadMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/ThreadMonitors.java
+++ b/src/main/java/net/openhft/chronicle/threads/ThreadMonitors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/Threads.java
+++ b/src/main/java/net/openhft/chronicle/threads/Threads.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/TimedEventHandler.java
+++ b/src/main/java/net/openhft/chronicle/threads/TimedEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/TimingPauser.java
+++ b/src/main/java/net/openhft/chronicle/threads/TimingPauser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/VanillaEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/threads/VanillaEventLoop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/VanillaExecutorFactory.java
+++ b/src/main/java/net/openhft/chronicle/threads/VanillaExecutorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/YieldingPauser.java
+++ b/src/main/java/net/openhft/chronicle/threads/YieldingPauser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/main/java/net/openhft/chronicle/threads/example/package-info.java
+++ b/src/main/java/net/openhft/chronicle/threads/example/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Example code showing basic Chronicle Threads usage.

--- a/src/main/java/net/openhft/chronicle/threads/internal/EventLoopStateRenderer.java
+++ b/src/main/java/net/openhft/chronicle/threads/internal/EventLoopStateRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads.internal;
 

--- a/src/main/java/net/openhft/chronicle/threads/internal/EventLoopThreadHolder.java
+++ b/src/main/java/net/openhft/chronicle/threads/internal/EventLoopThreadHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads.internal;
 

--- a/src/main/java/net/openhft/chronicle/threads/internal/EventLoopUtil.java
+++ b/src/main/java/net/openhft/chronicle/threads/internal/EventLoopUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads.internal;
 

--- a/src/main/java/net/openhft/chronicle/threads/internal/ThreadMonitorHarness.java
+++ b/src/main/java/net/openhft/chronicle/threads/internal/ThreadMonitorHarness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads.internal;
 

--- a/src/main/java/net/openhft/chronicle/threads/internal/ThreadsThreadHolder.java
+++ b/src/main/java/net/openhft/chronicle/threads/internal/ThreadsThreadHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads.internal;
 

--- a/src/main/java/net/openhft/chronicle/threads/internal/package-info.java
+++ b/src/main/java/net/openhft/chronicle/threads/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/src/main/java/net/openhft/chronicle/threads/package-info.java
+++ b/src/main/java/net/openhft/chronicle/threads/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Event loop implementations and utilities for running deterministic

--- a/src/test/java/net/openhft/chronicle/threads/BlockingEventLoopTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/BlockingEventLoopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/DiskSpaceMonitorTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/DiskSpaceMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/EventGroupBadAffinityTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventGroupBadAffinityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/EventGroupHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventGroupHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/EventGroupStressTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventGroupStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/EventGroupTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/EventLoopConcurrencyStressTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventLoopConcurrencyStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/EventLoopsTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/EventLoopsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/Issue251Test.java
+++ b/src/test/java/net/openhft/chronicle/threads/Issue251Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/LongPauserBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/threads/LongPauserBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/LongPauserTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/LongPauserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/LoopIntrospectionTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/LoopIntrospectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/MediumEventLoopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/PauserTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/PauserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/PauserTimeoutTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/PauserTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/StopVCloseTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/StopVCloseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/TestEventHandlers.java
+++ b/src/test/java/net/openhft/chronicle/threads/TestEventHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/ThreadMonitorsTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/ThreadMonitorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/ThreadsTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/ThreadsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/ThreadsTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/threads/ThreadsTestCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/VanillaEventLoopTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/VanillaEventLoopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/YieldingPauserTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/YieldingPauserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads;
 

--- a/src/test/java/net/openhft/chronicle/threads/example/SingleAndMultiThreadedExample.java
+++ b/src/test/java/net/openhft/chronicle/threads/example/SingleAndMultiThreadedExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads.example;
 

--- a/src/test/java/net/openhft/chronicle/threads/internal/EventLoopStateRendererTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/internal/EventLoopStateRendererTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads.internal;
 

--- a/src/test/java/net/openhft/chronicle/threads/internal/ThreadMonitorHarnessTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/internal/ThreadMonitorHarnessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads.internal;
 

--- a/src/test/java/net/openhft/chronicle/threads/internal/ThreadsThreadHolderTest.java
+++ b/src/test/java/net/openhft/chronicle/threads/internal/ThreadsThreadHolderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.threads.internal;
 

--- a/system.properties
+++ b/system.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+# Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 #
 
 # Tracing if resources are closed/released correctly.


### PR DESCRIPTION
## Summary
- Rolls `Copyright YYYY-20XX chronicle.software` / `higherfrequencytrading.com` forward so the end year matches the current calendar year (2026).
- Non-chronicle copyrights (third-party headers, etc.) are intentionally left alone.
- Adds a local `license.year=2013-2026` override in the project POM so `license-maven-plugin` validates the updated headers correctly on CI.
- Behaviour-neutral; no logic changes.

## Test plan
- [ ] Visual diff review - expect header year updates plus the `license.year` POM override.
- [ ] `mvn -DskipTests license:check`
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)