### PR TITLE
docs: restore the Threads Maven Central badge

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@ Chronicle Software
 :toclevels: 2
 :icons: font
 
-image:https://maven-badges.herokuapp.com/maven-central/net.openhft/chronicle-threads/badge.svg[caption="",link=https://maven-badges.herokuapp.com/maven-central/net.openhft/chronicle-threads]
+image:https://img.shields.io/maven-central/v/net.openhft/chronicle-threads.svg[caption="",link=https://central.sonatype.com/artifact/net.openhft/chronicle-threads]
 image:https://javadoc.io/badge2/net.openhft/chronicle-threads/javadoc.svg[link="https://www.javadoc.io/doc/net.openhft/chronicle-threads/latest/index.html"]
 image:https://img.shields.io/github/license/OpenHFT/Chronicle-Threads[GitHub]
 image:https://img.shields.io/badge/release%20notes-subscribe-brightgreen[link="https://chronicle.software/release-notes/"]


### PR DESCRIPTION
Replace the README version badge with [Shields' Maven Central API](https://shields.io/badges/maven-central-version) and link it to [net.openhft:chronicle-threads](https://central.sonatype.com/artifact/net.openhft/chronicle-threads). [The badge service's migration notice](https://github.com/softwaremill/maven-badges#readme) deprecated the Heroku URL and limited its availability to the end of 2025.

Validation on 9 September 2026: rendered the full README with Asciidoctor 2.0.20 without warnings; checked the rendered badge's destination and the POM coordinate. The badge SVG returned HTTP 200 with a version label, and the artifact page returned HTTP 200 for the intended artifact. `git diff --check` passes. The diff is one README line; Java tests were not rerun for this documentation edit.
