### PR TITLE
docs: fix common typos

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -108,7 +108,7 @@ public final class UninstallingEventHandler implements EventHandler {
 === Event Loops
 
 Chronicle Threads contains a number of event loop implementations.
-These are aggregated together in the link:src/main/java/net/openhft/chronicle/threads/EventGroup.java[`EventGroup`], and the general recommendation is to make use of this, although the other implementations of `EventLoop` can of course by used, or the user can implement their own.
+These are aggregated together in the link:src/main/java/net/openhft/chronicle/threads/EventGroup.java[`EventGroup`], and the general recommendation is to make use of this, although the other implementations of `EventLoop` can of course be used, or the user can implement their own.
 The `EventGroup` also automatically enables <<Performance Monitoring>>..
 
 ==== Creating event loop

--- a/src/main/java/net/openhft/chronicle/threads/DiskSpaceMonitor.java
+++ b/src/main/java/net/openhft/chronicle/threads/DiskSpaceMonitor.java
@@ -67,8 +67,8 @@ public enum DiskSpaceMonitor implements Runnable, Closeable {
         } else {
             this.notifyDiskLow = new NotifyDiskLowLogWarn();
         }
-        boolean diabled = Jvm.getBoolean("chronicle.disk.monitor.disable");
-        if (!diabled) {
+        boolean disabled = Jvm.getBoolean("chronicle.disk.monitor.disable");
+        if (!disabled) {
             executor = Threads.acquireScheduledExecutorService(DISK_SPACE_CHECKER_NAME, true);
             long period = Jvm.getLong("chronicle.disk.monitor.period", 10L);
             executor.scheduleAtFixedRate(this, period, period, TimeUnit.SECONDS);


### PR DESCRIPTION
## Summary
Typo fixes covering: `locaiton`, `receieved`, `visibe`, `receipient`, `Signtaure`, `signatire`, `extenstions`, `diabled`, `overriden`, `sl4j`, `andd`, `resuable`, `endian-independant`, `benchamrk`, `by used`/`will replaced`, and the `CPI` -> `CPU` slip in AffinityLock javadoc.

Behaviour-neutral, but includes one code edit: local variable rename `diabled` -> `disabled` in `DiskSpaceMonitor`.

## Test plan
- [ ] Diff is limited to typo/text cleanup plus the `DiskSpaceMonitor` local rename.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)