### PR TITLE
docs: replace above-U+00FF characters with 8-bit equivalents

### DIFF
--- a/src/main/adoc/project-requirements.adoc
+++ b/src/main/adoc/project-requirements.adoc
@@ -1,4 +1,4 @@
-= Chronicle Threads – Functional Requirements Specification
+= Chronicle Threads - Functional Requirements Specification
 :revnumber: 1.0
 :revdate: 2025-05-25
 :toc:
@@ -28,7 +28,7 @@ ultra-low-latency, event-driven Java systems.
 |*EventHandler* |Application-provided component that implements `action()`; executed by an `EventLoop`.
 |*EventGroup* |A container that manages one or more `EventLoop`s, potentially including a dedicated monitor loop.
 |*Pauser* |Strategy object that controls how an idle loop waits (e.g., busy-spin, yield, sleep).
-|*Fast Thread* |A thread—usually pinned to an isolated CPU core—running a latency-critical event loop.
+|*Fast Thread* |A thread--usually pinned to an isolated CPU core--running a latency-critical event loop.
 |*Hot Path* / *Fast Path* |The code execution path that is performance-critical and frequently executed, where low latency and minimal overhead are paramount.
 |*Loop-Block Monitor* |Background handler that measures `EventHandler` run-time and logs outliers exceeding a configured threshold.
 |*NUMA* |Non-Uniform Memory Access; a memory architecture where memory access time depends on the memory location relative to a processor.
@@ -44,7 +44,7 @@ ultra-low-latency, event-driven Java systems.
 
 == 4 High-Level Functional Requirements
 
-=== 4.1 Event‐Loop Lifecycle and Configuration
+=== 4.1 Event-Loop Lifecycle and Configuration
 
 . *Creation and Configuration*
 *THR-FN-001* The library SHALL provide builder APIs (e.g., `EventLoopBuilder`, `EventGroupBuilder`) for fluent and immutable configuration of event loops and groups.

--- a/src/main/docs/project-requirements.adoc
+++ b/src/main/docs/project-requirements.adoc
@@ -1,4 +1,4 @@
-= Chronicle Threads – Functional Requirements Specification
+= Chronicle Threads - Functional Requirements Specification
 :revnumber: 1.0
 :revdate: 2025-05-25
 :sectnums:
@@ -26,7 +26,7 @@ _Out of scope_ are:
 |_EventHandler_ |Application-provided component that implements `action()`; executed by an `EventLoop`.
 |_EventGroup_ |A container that manages one or more `EventLoop`s, potentially including a dedicated monitor loop.
 |_Pauser_ |Strategy object that controls how an idle loop waits (e.g., busy-spin, yield, sleep).
-|_Fast Thread_ |A thread—usually pinned to an isolated CPU core—running a latency-critical event loop.
+|_Fast Thread_ |A thread--usually pinned to an isolated CPU core--running a latency-critical event loop.
 |_Hot Path_ / _Fast Path_ |The code execution path that is performance-critical and frequently executed, where low latency and minimal overhead are paramount.
 |_Loop-Block Monitor_ |Background handler that measures `EventHandler` run-time and logs outliers exceeding a configured threshold.
 |_NUMA_ |Non-Uniform Memory Access; a memory architecture where memory access time depends on the memory location relative to a processor.
@@ -42,7 +42,7 @@ _Out of scope_ are:
 
 == High-Level Functional Requirements
 
-=== Event‐Loop Lifecycle and Configuration
+=== Event-Loop Lifecycle and Configuration
 
 . _Creation and Configuration_
 _THR-FN-001_ The library SHALL provide builder APIs (e.g., `EventLoopBuilder`, `EventGroupBuilder`) for fluent and immutable configuration of event loops and groups.


### PR DESCRIPTION
## Summary
Documentation is expected to stay within 8-bit (1-255) so characters outside that range are folded to their closest Latin-1/ASCII forms:

| Before | After |
|--------|-------|
| en-dash, non-breaking hyphen, figure dash | `-` |
| em-dash, horizontal bar | `--` |
| ellipsis | `...` |
| zero-width space / joiners / direction marks | *removed* |
| smart single quotes `'` `'` | `'` |
| smart double quotes `"` `"` | `"` |
| `<=`, `>=` | `<=`, `>=` |

Latin-1 characters (micro sign, non-breaking space, etc.) are left alone.

## Test plan
- [ ] Rendered output still reads naturally.
- [ ] No code semantics affected (text-only files).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)