### PR TITLE
Disable automatic unit-test retries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <!-- Keep failures visible even when CI requests retries on the command line. -->
+                    <rerunFailingTestsCount>0</rerunFailingTestsCount>
                     <forkCount>4</forkCount>
                     <reuseForks>true</reuseForks>
                     <runOrder>hourly</runOrder>

--- a/src/main/docs/decision-log.adoc
+++ b/src/main/docs/decision-log.adoc
@@ -1,5 +1,6 @@
 = Chronicle Threads - Decision Log
 :toc:
+:sectnums:
 :lang: en-GB
 :source-highlighter: rouge
 
@@ -14,6 +15,7 @@ Numbers are unique within the THR scope.
 * link:#THR-OPS-003[THR-OPS-003 Background disk-space monitoring]
 * link:#THR-DOC-004[THR-DOC-004 Nine-Box taxonomy for requirements and decisions]
 * link:#THR-FN-005[THR-FN-005 EventGroup priority sets gate handler registration]
+* link:#THR-TEST-006[THR-TEST-006 Preserve first-attempt unit-test failures]
 
 == Decision Records
 
@@ -227,3 +229,19 @@ Impact & Consequences::
 Notes/Links::
 * Requirements: link:project-requirements.adoc[THR-FN-004 and THR-FN-005 handler management requirements].
 * Key types: `EventGroup`, `EventGroupBuilder.withPriorities(java.util.Set)`, `HandlerPriority`.
+
+[[THR-TEST-006]]
+=== THR-TEST-006 Preserve first-attempt unit-test failures
+
+Date:: 2026-09-12
+Decision Statement::
+* Set Surefire `rerunFailingTestsCount` to the literal value `0`.
+* Command-line properties, including `-Dsurefire.rerunFailingTestsCount=3`, must not enable automatic retries.
+Rationale for Decision::
+* An intermittent failure must retain its original outcome for investigation.
+Validation::
+* A probe that fails first and would pass on retry must execute once and leave Maven failed.
+* Check inherited profiles in the effective POM and retain first-attempt results from lifecycle verification.
+Impact & Consequences::
+* Explicitly recorded, bounded repeat runs remain useful for diagnosis.
+* CI must still handle reported failures when `maven.test.failure.ignore` allows later build steps to continue.


### PR DESCRIPTION
Shared CI command lines can enable Surefire retries and turn a first-attempt failure into a successful build. Set `rerunFailingTestsCount` to a literal `0`, so `-Dsurefire.rerunFailingTestsCount=3` cannot enable automatic reruns. This follows OpenHFT/Chronicle-Core#870.

Validation used isolated baseline/candidate Maven repositories:

- Fail-first probes (jupiter-dynamic, jupiter-ordinary): develop invoked each twice and succeeded; this branch invoked each once and failed as intended with three retries requested.
- Verified zero retries in 2 effective project/profile configurations: default, sonar.
- `mvn -q clean verify -Dsurefire.rerunFailingTestsCount=3`: passed; 171 tests reported, 0 failures, 0 errors, 1 skipped and 0 rerun records. Test JVM: 21.0.12.

Platform CI and reviewer approval remain separate merge requirements. CI must still handle reported failures when `maven.test.failure.ignore` allows later steps to continue.

At published head `4a827640a45c11aad191258d75e333113328a500`, [Zing Java 8 build 1357917](https://teamcity.chronicle.software/buildConfiguration/Chronicle_ChronicleThreads_SnapshotZing8/1357917) failed `YieldingPauserTest.pause`: expected 100.0, observed 146.0. The local Java 21 suite passed. The Zing timing failure remains unclassified pending a matched develop/candidate control; Threads maintainers should investigate timer and scheduling behaviour with retries disabled. This CI failure is not cleared by the local pass.
